### PR TITLE
non-global instance of key set resetting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,4 +10,4 @@ sphinx:
 
 python:
    install:
-   - requirements: python/gink/requirements.txt
+   - requirements: python/requirements.txt

--- a/python/gink/impl/coding.py
+++ b/python/gink/impl/coding.py
@@ -244,7 +244,7 @@ def create_deleting_entry(muid: Muid, key: Union[UserKey, None, Muid, Tuple[Muid
     entry_builder.behavior = behavior
     muid.put_into(entry_builder.container)  # type: ignore
     entry_builder.deletion = True  # type: ignore
-    if behavior == DIRECTORY:
+    if behavior in (DIRECTORY, KEY_SET):
         assert isinstance(key, (int, str, bytes))
         encode_key(key, entry_builder.key)  # type: ignore
     elif behavior == BOX:
@@ -274,7 +274,7 @@ def decode_entry_occupant(entry_muid: Muid, builder: EntryBuilder) -> Union[User
         return Muid.create(builder=builder.pointee, context=entry_muid)
     if builder.HasField("value"):  # type: ignore
         return decode_value(builder.value)
-    if builder.behavior == ROLE:
+    if builder.behavior in (ROLE, KEY_SET):
         return inclusion
     raise ValueError(f"can't interpret {builder}")
 

--- a/python/gink/impl/lmdb_store.py
+++ b/python/gink/impl/lmdb_store.py
@@ -264,7 +264,7 @@ class LmdbStore(AbstractStore):
             trxn: Trxn) -> Iterable[ChangeBuilder]:
         """ Figures out which specific reset method to call to reset a container. """
         behavior = self._get_behavior(container, trxn)
-        if behavior in (DIRECTORY, BOX, ROLE, PROPERTY):
+        if behavior in (DIRECTORY, BOX, ROLE, PROPERTY, KEY_SET):
             for change in self._get_keyed_reset(container, to_time, trxn, seen, None, behavior):
                 yield change
             return

--- a/python/gink/tests/test_database.py
+++ b/python/gink/tests/test_database.py
@@ -9,6 +9,7 @@ from ..impl.bundler import Bundler
 from ..impl.bundle_info import BundleInfo
 from ..impl.directory import Directory
 from ..impl.sequence import Sequence
+from ..impl.key_set import KeySet
 
 
 def test_database():
@@ -67,18 +68,25 @@ def test_reset_everything():
             database = Database(store=store)
             root = Directory.get_global_instance(database=database)
             queue = Sequence.get_global_instance(database=database)
+            ks = KeySet(database=database)
             misc = Directory()
+
             misc[b"yes"] = False
             root["foo"] = "bar"
             queue.append("something")
+            ks.add("key1")
+
             assert len(root) == 1
             assert len(queue) == 1
             assert len(misc) == 1
+            assert len(ks) == 1
             database.reset()
             assert len(root) == 0, root.dumps()
             assert len(queue) == 0
             assert len(misc) == 0
+            assert len(ks) == 0
             database.reset(to_time=-1)
             assert len(root) == 1
             assert len(queue) == 1
             assert len(misc) == 1
+            assert len(ks) == 1


### PR DESCRIPTION
Key Set now resets with Database.reset() (kind of).

I'm going to add an issue with this, but for some reason KeySet.get_global_instance() cannot be reset through Database.reset(), but a normal key set can now be reset.

to_last_with_prefix() is not finding the global keyset in the database.

This PR is also an excuse to fix my file path typo for the requirements.txt to build the docs :)