### PR TITLE
browser tests working on rpi

### DIFF
--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -27,12 +27,13 @@ ENV DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
 
 # Install Google Chrome Stable and fonts
 # Note: this installs the necessary libs to make the browser work with Puppeteer.
-RUN apt-get update && apt-get install gnupg wget -y && \
+RUN if [ `uname -m` != aarch64 ]; then apt-get update && apt-get install gnupg wget -y && \
   wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
   sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
   apt-get update && \
   apt-get install google-chrome-stable -y --no-install-recommends && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/*; fi
+RUN if [ `uname -m` != aarch64 ]; then apt update && apt install chromium-browser && export CHROME_BIN=/usr/bin/chromium-browser; fi
 RUN npm run browser-unit
 RUN npm run browser-integration
 RUN ./integration-tests/node-client-test.js

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -33,7 +33,7 @@ RUN if [ `uname -m` != aarch64 ]; then apt-get update && apt-get install gnupg w
   apt-get update && \
   apt-get install google-chrome-stable -y --no-install-recommends && \
   rm -rf /var/lib/apt/lists/*; fi
-RUN if [ `uname -m` != aarch64 ]; then apt update && apt install chromium-browser && export CHROME_BIN=/usr/bin/chromium-browser; fi
+RUN if [ `uname -m` == aarch64 ]; then apt update && apt install chromium-browser && export CHROME_BIN=/usr/bin/chromium-browser; fi
 RUN npm run browser-unit
 RUN npm run browser-integration
 RUN ./integration-tests/node-client-test.js

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -32,7 +32,7 @@ RUN if [ `uname -m` != aarch64 ]; then apt-get update && apt-get install gnupg w
   sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
   apt-get update && \
   apt-get install google-chrome-stable -y --no-install-recommends && \
-  rm -rf /var/lib/apt/lists/*; fi
+  rm -rf /var/lib/apt/lists/* && export CHROME_BIN=/usr/bin/chrome; fi
 RUN if [ `uname -m` == aarch64 ]; then apt update && apt install chromium-browser && export CHROME_BIN=/usr/bin/chromium-browser; fi
 RUN npm run browser-unit
 RUN npm run browser-integration

--- a/javascript/integration-tests/browser-client-test/browser.test.js
+++ b/javascript/integration-tests/browser-client-test/browser.test.js
@@ -3,14 +3,17 @@ const Expector = require("../Expector");
 const { expect } = require('@jest/globals');
 
 it('connect to server and display commits', async () => {
-    let browser = await puppeteer.launch({
-        executablePath: '/usr/bin/google-chrome',
-        headless: "new",
-        args: [
-            "--no-sandbox",
-            "--disable-gpu",
-        ]
-    });
+    if (process.env.CHROME_BIN) {
+        let browser = await puppeteer.launch({
+            executablePath: process.env.CHROME_BIN,
+            headless: "new",
+            args: [
+                "--no-sandbox",
+                "--disable-gpu",
+            ]
+        });
+    }
+
     let page = await browser.newPage();
 
     const server = new Expector("node", ["./tsc.out/implementation/main.js"],

--- a/javascript/integration-tests/browser-client-test/browser.test.js
+++ b/javascript/integration-tests/browser-client-test/browser.test.js
@@ -49,17 +49,17 @@ it('connect to server and display commits', async () => {
     await page.goto('http://127.0.0.1:8081/integration-tests/browser-client-test');
     await page.waitForSelector('#messages');
 
-    // if you are using a RaspberryPi, or another low powered machine, uncomment these.
-    // const rpiIsSlow = new Promise(r => setTimeout(r, 3000));
-    // await rpiIsSlow;
+    // if you are using a RaspberryPi, or another low powered machine, make sure these are uncommented
+    const slowMachine = new Promise(r => setTimeout(r, 3000));
+    await slowMachine;
 
     await waitForMessages;
 
     const messages = await page.$eval("#messages", e => e.innerHTML);
 
+    await server.close();
+    await browser.close();
+
     const expectedMessages = /Messages go here\..*Hello, Universe!.*start: SimpleServer/s
     expect(messages).toMatch(expectedMessages);
-
-    server.close();
-    browser.close();
-}, 13000)
+}, 13000);

--- a/javascript/integration-tests/browser-client-test/browser.test.js
+++ b/javascript/integration-tests/browser-client-test/browser.test.js
@@ -3,21 +3,40 @@ const Expector = require("../Expector");
 const { expect } = require('@jest/globals');
 
 it('connect to server and display commits', async () => {
+    let launch_options;
+    // for this test to run as intended, set env CHROME_BIN
+    // to the path to the chrome binary. Chromium works too.
+    // ex: export CHROME_BIN=/bin/chromium-browser
     if (process.env.CHROME_BIN) {
-        let browser = await puppeteer.launch({
+        launch_options = {
             executablePath: process.env.CHROME_BIN,
             headless: "new",
             args: [
                 "--no-sandbox",
                 "--disable-gpu",
             ]
-        });
+        }
     }
+    else {
+        // if path to chrome is not specified, try to find it.
+        launch_options = {
+            product: 'chrome',
+            headless: "new",
+            args: [
+                "--no-sandbox",
+                "--disable-gpu",
+            ]
+        }
+    }
+    let browser = await puppeteer.launch(launch_options);
 
     let page = await browser.newPage();
 
+    const waitForMessages = new Promise(r => setTimeout(r, 1000));
+
     const server = new Expector("node", ["./tsc.out/implementation/main.js"],
         { env: { GINK_PORT: "8081", GINK_STATIC_PATH: ".", ...process.env } });
+    await waitForMessages;
     await server.expect("ready");
 
     // For some reason if I don't handle console output, this test fails because
@@ -30,7 +49,10 @@ it('connect to server and display commits', async () => {
     await page.goto('http://127.0.0.1:8081/integration-tests/browser-client-test');
     await page.waitForSelector('#messages');
 
-    const waitForMessages = new Promise(r => setTimeout(r, 1000));
+    // if you are using a RaspberryPi, or another low powered machine, uncomment these.
+    // const rpiIsSlow = new Promise(r => setTimeout(r, 3000));
+    // await rpiIsSlow;
+
     await waitForMessages;
 
     const messages = await page.$eval("#messages", e => e.innerHTML);
@@ -40,4 +62,4 @@ it('connect to server and display commits', async () => {
 
     server.close();
     browser.close();
-}, 10000)
+}, 13000)

--- a/javascript/karma.conf.js
+++ b/javascript/karma.conf.js
@@ -31,6 +31,7 @@ module.exports = function (config) {
                     "path": false,
                     "fs": false,
                     "http": false,
+                    "url": false,
                     "https": false,
                     "readline": false,
                     "console": false,

--- a/javascript/karma.conf.js
+++ b/javascript/karma.conf.js
@@ -14,6 +14,9 @@ module.exports = function (config) {
         singleRun: true,
         logLevel: config.LOG_WARN,
         frameworks: ['jasmine', 'webpack'],
+        // for the tests to run as intended, set env CHROME_BIN
+        // to the path to the chrome binary. Chromium works too.
+        // ex: export CHROME_BIN=/bin/chromium-browser
         browsers: ['ChromeHeadlessNS'],
         customLaunchers: {
             ChromeHeadlessNS: {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -41,6 +41,8 @@
     "fs-ext": "^2.0.0",
     "google-protobuf": "^3.21.2",
     "idb": "^7.1.1",
+    "karma": "^6.4.2",
+    "karma-mocha-reporter": "^2.2.5",
     "node-static": "^0.7.11",
     "websocket": "^1.0.34"
   },
@@ -49,13 +51,14 @@
     "@types/jest": "^29.5.0",
     "expect": "^29.7.0",
     "jest-puppeteer": "^9.0.1",
+    "karma-chrome-launcher": "^3.2.0",
+    "karma-jasmine": "^5.1.0",
     "karma-webpack": "^5.0.0",
     "node-loader": "^2.0.0",
     "puppeteer": "^21.4.1",
     "ts-jest": "^29.0.5",
     "ts-loader": "^9.5.0",
     "webpack": "^5.89.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-karma-jasmine": "^4.0.0"
+    "webpack-cli": "^5.1.4"
   }
 }


### PR DESCRIPTION
Still having trouble with browser unit tests specifically on my M1 mac. I'll keep playing around with that, but this should be a step forward. I left comments in the test files, but make sure to set env CHROME_BIN=/usr/bin/chrome or whatever your path to chrome/chromium is for the tests to run.

This also removes a bunch of bloat karma-launchers that we aren't using by removing the webpack-karma-jasmine package.