### PR TITLE
limit reuse of transactions

### DIFF
--- a/javascript/implementation/IndexedDbStore.ts
+++ b/javascript/implementation/IndexedDbStore.ts
@@ -134,6 +134,7 @@ export class IndexedDbStore implements Store {
         if (this.transaction === null || this.lastCaller != callerLine) {
             // console.log(`creating new transaction for ${callerLine}`)
             this.lastCaller = callerLine;
+            this.countTrxns += 1;
             this.transaction = this.wrapped.transaction(
                 ['entries', 'clearances', 'removals', 'trxns', 'chainInfos', 'activeChains', 'containers'],
                 'readwrite');


### PR DESCRIPTION
Inspects the call stack to limit reuse of transactions to matching use cases.
(Note: probably will not rely on the call-stack inspection in the future, this is just a temporary work around.)