### PR TITLE
moved back to individual transactions for everything other than adding a bundle

### DIFF
--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -34,6 +34,8 @@ RUN if [ `uname -m` != aarch64 ]; then apt-get update && apt-get install gnupg w
   apt-get install google-chrome-stable -y --no-install-recommends && \
   rm -rf /var/lib/apt/lists/* && export CHROME_BIN=/usr/bin/chrome; fi
 RUN if [ `uname -m` == aarch64 ]; then apt update && apt install chromium-browser && export CHROME_BIN=/usr/bin/chromium-browser; fi
+
+COPY static ./static
 RUN npm run browser-unit
 RUN npm run browser-integration
 RUN ./integration-tests/node-client-test.js

--- a/javascript/implementation/IndexedDbStore.ts
+++ b/javascript/implementation/IndexedDbStore.ts
@@ -262,11 +262,7 @@ export class IndexedDbStore implements Store {
         Promise<Transaction> {
         // console.log(`starting addBundleHelper for: ` + JSON.stringify(bundleInfo));
         const { timestamp, medallion, chainStart, priorTime } = bundleInfo;
-
-        // Issue here
-        /////////////////////////////////////////////
-        const wrappedTransaction = this.getTransaction(); // This instantly errors - check console.
-        /////////////////////////////////////////////
+        const wrappedTransaction = this.getTransaction();
 
         const oldChainInfo: BundleInfo = await wrappedTransaction.objectStore("chainInfos").get([medallion, chainStart]);
         if (oldChainInfo || priorTime) {

--- a/javascript/implementation/IndexedDbStore.ts
+++ b/javascript/implementation/IndexedDbStore.ts
@@ -151,7 +151,7 @@ export class IndexedDbStore implements Store {
 
     async dropHistory(container?: Muid, before?: AsOf): Promise<void> {
         const beforeTs = before ? await this.asOfToTimestamp(before) : generateTimestamp();
-        const trxn = this.getTransaction();
+        const trxn = this.wrapped.transaction(["removals", "entries"], "readwrite");
         let removalsCursor = await trxn.objectStore("removals").openCursor(IDBKeyRange.upperBound([beforeTs]));
         if (container) {
             const containerTuple = muidToTuple(container);
@@ -200,7 +200,7 @@ export class IndexedDbStore implements Store {
         }
         if (asOf < 0 && asOf > -1000) {
             // Interpret as number of commits in the past.
-            let cursor = await this.getTransaction().objectStore("trxns").openCursor(undefined, "prev");
+            let cursor = await this.wrapped.transaction("trxns", "readonly").objectStore("trxns").openCursor(undefined, "prev");
             let commitsToTraverse = -asOf;
             for (; cursor; cursor = await cursor.continue()) {
                 if (--commitsToTraverse == 0) {
@@ -216,7 +216,7 @@ export class IndexedDbStore implements Store {
 
     async getClaimedChains(): Promise<ClaimedChains> {
         if (!this.initialized) throw new Error("not initilized");
-        const objectStore = this.getTransaction().objectStore("activeChains");
+        const objectStore = this.wrapped.transaction("activeChains", "readonly").objectStore("activeChains");
         const items = await objectStore.getAll();
         const result = new Map();
         for (let i = 0; i < items.length; i++) {
@@ -228,7 +228,7 @@ export class IndexedDbStore implements Store {
     async claimChain(medallion: Medallion, chainStart: ChainStart): Promise<void> {
         //TODO(https://github.com/google/gink/issues/29): check for medallion reuse
         await this.ready;
-        const wrappedTransaction = this.getTransaction();
+        const wrappedTransaction = this.wrapped.transaction("activeChains", "readwrite");
         await wrappedTransaction.objectStore('activeChains').add({ chainStart, medallion });
         return wrappedTransaction.done;
     }
@@ -242,7 +242,7 @@ export class IndexedDbStore implements Store {
 
     private async getChainInfos(): Promise<Array<BundleInfo>> {
         await this.ready;
-        return await this.getTransaction().objectStore('chainInfos').getAll();
+        return await this.wrapped.transaction("chainInfos", "readonly").objectStore('chainInfos').getAll();
     }
 
     addBundle(bundleBytes: BundleBytes): Promise<BundleInfo> {
@@ -427,13 +427,13 @@ export class IndexedDbStore implements Store {
 
     async getContainerBytes(address: Muid): Promise<Bytes | undefined> {
         const addressTuple = [address.timestamp, address.medallion, address.offset];
-        return await this.getTransaction().objectStore('containers').get(<MuidTuple>addressTuple);
+        return await this.wrapped.transaction("containers", "readonly").objectStore('containers').get(<MuidTuple>addressTuple);
     }
 
     async getEntryByKey(container?: Muid, key?: KeyType | Muid | [Muid | Container, Muid | Container], asOf?: AsOf): Promise<Entry | undefined> {
         const asOfTs = asOf ? (await this.asOfToTimestamp(asOf)) : Infinity;
         const desiredSrc = [container?.timestamp ?? 0, container?.medallion ?? 0, container?.offset ?? 0];
-        const trxn = this.getTransaction();
+        const trxn = this.wrapped.transaction(["clearances", "entries"], "readonly");
         let clearanceTime: Timestamp = 0;
         const clearancesSearch = IDBKeyRange.bound([desiredSrc], [desiredSrc, [asOfTs]]);
         const clearancesCursor = await trxn.objectStore("clearances").openCursor(clearancesSearch, "prev");
@@ -465,7 +465,7 @@ export class IndexedDbStore implements Store {
     async getKeyedEntries(container: Muid, asOf?: AsOf): Promise<Map<KeyType, Entry>> {
         const asOfTs = asOf ? (await this.asOfToTimestamp(asOf)) : Infinity;
         const desiredSrc = [container?.timestamp ?? 0, container?.medallion ?? 0, container?.offset ?? 0];
-        const trxn = this.getTransaction();
+        const trxn = this.wrapped.transaction(["clearances", "entries"], "readonly");
 
         let clearanceTime: Timestamp = 0;
         const clearancesSearch = IDBKeyRange.bound([desiredSrc], [desiredSrc, [asOfTs]]);
@@ -517,7 +517,7 @@ export class IndexedDbStore implements Store {
         } else {
             unfiltered = await this.wrapped.getAllFromIndex("entries", "targets", indexable);
         }
-        const trxn = this.getTransaction();
+        const trxn = this.wrapped.transaction(["removals"], "readonly");
         const returning: Entry[] = [];
         const removals = trxn.objectStore("removals");
         for (let i = 0; i < unfiltered.length; i++) {
@@ -549,7 +549,7 @@ export class IndexedDbStore implements Store {
         const lower = [containerId, 0];
         const upper = [containerId, asOfTs];
         const range = IDBKeyRange.bound(lower, upper);
-        const trxn = this.getTransaction();
+        const trxn = this.wrapped.transaction(["clearances", "entries", "removals"], "readonly");
 
         let clearanceTime: Timestamp = 0;
         const clearancesSearch = IDBKeyRange.bound([containerId], [containerId, [asOfTs]]);
@@ -580,7 +580,7 @@ export class IndexedDbStore implements Store {
         const asOfTs: Timestamp = asOf ? (await this.asOfToTimestamp(asOf)) : generateTimestamp();
         const entryId = [entryMuid.timestamp ?? 0, entryMuid.medallion ?? 0, entryMuid.offset ?? 0];
         const entryRange = IDBKeyRange.bound([entryId, [0]], [entryId, [asOfTs]]);
-        const trxn = this.getTransaction();
+        const trxn = this.wrapped.transaction(["entries", "removals"], "readonly");
         const entryCursor = await trxn.objectStore("entries").index("locations").openCursor(entryRange, "prev");
         if (!entryCursor) {
             return undefined;
@@ -596,17 +596,17 @@ export class IndexedDbStore implements Store {
 
     // for debugging, not part of the api/interface
     async getAllEntryKeys() {
-        return await this.getTransaction().objectStore("entries").getAllKeys();
+        return await this.wrapped.transaction("entries", "readonly").objectStore("entries").getAllKeys();
     }
 
     // for debugging, not part of the api/interface
     async getAllEntries(): Promise<Entry[]> {
-        return await this.getTransaction().objectStore("entries").getAll();
+        return await this.wrapped.transaction("entries", "readonly").objectStore("entries").getAll();
     }
 
     // for debugging, not part of the api/interface
     async getAllRemovals() {
-        return await this.getTransaction().objectStore("removals").getAll();
+        return await this.wrapped.transaction("removals", "readonly").objectStore("removals").getAll();
     }
 
     // Note the IndexedDB has problems when await is called on anything unrelated
@@ -615,7 +615,7 @@ export class IndexedDbStore implements Store {
         await this.ready;
 
         // We loop through all commits and send those the peer doesn't have.
-        for (let cursor = await this.getTransaction().objectStore("trxns").openCursor();
+        for (let cursor = await this.wrapped.transaction("trxns", "readonly").objectStore("trxns").openCursor();
             cursor; cursor = await cursor.continue()) {
             const commitKey = <BundleInfoTuple>cursor.key;
             const commitInfo = commitKeyToInfo(commitKey);

--- a/javascript/integration-tests/Expector.js
+++ b/javascript/integration-tests/Expector.js
@@ -17,6 +17,10 @@ module.exports = class Expector {
         const appender = this.notify.bind(this);
         this.proc.stdout.on('data', appender);
         this.proc.stderr.on('data', appender);
+        this.proc.on('error', (e) => {
+            console.log(e);
+            this.proc.close();
+        });
     }
 
     /**

--- a/javascript/integration-tests/dashboard.test.js
+++ b/javascript/integration-tests/dashboard.test.js
@@ -21,7 +21,7 @@ it('connect to server and display dashboard', async () => {
         // if path to chrome is not specified, try to find it.
         launch_options = {
             product: 'chrome',
-            headless: "false",
+            headless: "new",
             args: [
                 "--no-sandbox",
                 "--disable-gpu",
@@ -63,8 +63,12 @@ it('connect to server and display dashboard', async () => {
     await server.expect("Peer ::ffff:127.0.0.1 disconnected.");
 
     // Make sure server does not crash after page reload.
-    await server.expect("got ack from 2");
-
-    await server.close();
-    await browser.close();
+    try {
+        await server.expect("got ack from 2");
+    } catch (e) {
+        throw new Error(e);
+    } finally {
+        await server.close();
+        await browser.close();
+    }
 }, 13000);

--- a/javascript/integration-tests/dashboard.test.js
+++ b/javascript/integration-tests/dashboard.test.js
@@ -46,7 +46,7 @@ it('connect to server and display dashboard', async () => {
         const args = await Promise.all(e.args().map(a => a.jsonValue()));
     });
 
-    await page.goto('http://127.0.0.1:8081/');
+    await page.goto(`http://localhost:8081/`);
     await page.waitForSelector('#container-contents');
 
     // if you are using a RaspberryPi, or another low powered machine, make sure these are uncommented
@@ -57,7 +57,6 @@ it('connect to server and display dashboard', async () => {
 
     const title = await page.$eval("#title-bar", e => e.innerHTML);
     expect(title).toMatch("Root Directory");
-
 
     await page.reload();
     await server.expect("Peer ::ffff:127.0.0.1 disconnected.");

--- a/javascript/integration-tests/dashboard.test.js
+++ b/javascript/integration-tests/dashboard.test.js
@@ -1,0 +1,70 @@
+const puppeteer = require('puppeteer');
+const Expector = require("./Expector");
+const { expect } = require('@jest/globals');
+
+it('connect to server and display dashboard', async () => {
+    let launch_options;
+    // for this test to run as intended, set env CHROME_BIN
+    // to the path to the chrome binary. Chromium works too.
+    // ex: export CHROME_BIN=/bin/chromium-browser
+    if (process.env.CHROME_BIN) {
+        launch_options = {
+            executablePath: process.env.CHROME_BIN,
+            headless: "new",
+            args: [
+                "--no-sandbox",
+                "--disable-gpu",
+            ]
+        };
+    }
+    else {
+        // if path to chrome is not specified, try to find it.
+        launch_options = {
+            product: 'chrome',
+            headless: "false",
+            args: [
+                "--no-sandbox",
+                "--disable-gpu",
+            ]
+        };
+    }
+    let browser = await puppeteer.launch(launch_options);
+
+    let page = await browser.newPage();
+
+    const waitForMessages = new Promise(r => setTimeout(r, 1000));
+
+    const server = new Expector("node", ["./tsc.out/implementation/main.js"],
+        { env: { GINK_PORT: "8081", ...process.env } });
+    await waitForMessages;
+    await server.expect("ready");
+
+    // For some reason if I don't handle console output, this test fails because
+    // the messages aren't displayed properly..?
+    // TODO: Figure out why the test fails without page.on('console')
+    page.on('console', async e => {
+        const args = await Promise.all(e.args().map(a => a.jsonValue()));
+    });
+
+    await page.goto('http://127.0.0.1:8081/');
+    await page.waitForSelector('#container-contents');
+
+    // if you are using a RaspberryPi, or another low powered machine, make sure these are uncommented
+    const slowMachine = new Promise(r => setTimeout(r, 3000));
+    await slowMachine;
+
+    await waitForMessages;
+
+    const title = await page.$eval("#title-bar", e => e.innerHTML);
+    expect(title).toMatch("Root Directory");
+
+
+    await page.reload();
+    await server.expect("Peer ::ffff:127.0.0.1 disconnected.");
+
+    // Make sure server does not crash after page reload.
+    await server.expect("got ack from 2");
+
+    await server.close();
+    await browser.close();
+}, 13000);

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -32,7 +32,7 @@
     "build": "tsc",
     "test": "jest -- unit-tests",
     "browser-unit": "karma start",
-    "browser-integration": "jest -- browser.test.js",
+    "browser-integration": "jest --detectOpenHandles browser.test.js dashboard.test.js",
     "browser-performance": "node performance-tests/browser-performance-test.js"
   },
   "homepage": "https://github.com/x5e/gink#readme",


### PR DESCRIPTION
Also, added a test that makes sure the server does not crash when the page refreshes.

To run the test that fails locally:
`npm run browser-integration`