### PR TITLE
changed ports on some integration tests so they don't error on mac

### DIFF
--- a/javascript/integration-tests/browser-client-test/browser.test.js
+++ b/javascript/integration-tests/browser-client-test/browser.test.js
@@ -9,7 +9,7 @@ it('connect to server and display commits', async () => {
     let page = await browser.newPage();
 
     const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-        { env: { GINK_PORT: "8081", GINK_STATIC_PATH: ".", ...process.env } });
+        { env: { GINK_PORT: "8082", GINK_STATIC_PATH: ".", ...process.env } });
     await sleep(1000);
     await server.expect("ready");
 
@@ -20,7 +20,7 @@ it('connect to server and display commits', async () => {
         const args = await Promise.all(e.args().map(a => a.jsonValue()));
     });
 
-    await page.goto('http://127.0.0.1:8081/integration-tests/browser-client-test');
+    await page.goto('http://127.0.0.1:8082/integration-tests/browser-client-test');
     await page.waitForSelector('#messages');
 
     await sleep(4000);

--- a/javascript/integration-tests/dashboard.test.js
+++ b/javascript/integration-tests/dashboard.test.js
@@ -8,7 +8,7 @@ it('connect to server and display dashboard', async () => {
     let page = await browser.newPage();
 
     const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-        { env: { GINK_PORT: "8081", ...process.env } });
+        { env: { GINK_PORT: "8083", ...process.env } });
     await sleep(1000);
     await server.expect("ready");
 
@@ -16,7 +16,7 @@ it('connect to server and display dashboard', async () => {
         const args = await Promise.all(e.args().map(a => a.jsonValue()));
     });
 
-    await page.goto(`http://localhost:8081/`);
+    await page.goto(`http://localhost:8083/`);
     await page.waitForSelector('#root');
 
     await sleep(4000);
@@ -52,13 +52,13 @@ it('share commits between two pages', async () => {
     const pages = [page1, page2];
 
     const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-        { env: { GINK_PORT: "8081", ...process.env } });
+        { env: { GINK_PORT: "8084", ...process.env } });
     await sleep(1000);
     await server.expect("ready");
 
     try {
         for (const page of pages) {
-            await page.goto(`http://localhost:8081/`);
+            await page.goto(`http://localhost:8084/`);
             await page.waitForSelector('#root');
 
             page.on('dialog', async dialog => {


### PR DESCRIPTION
Something happens sometimes with the Mac integration tests where a port is still in use for the browser based integration tests, so I am making the ports different between the tests.