### PR TITLE
typescript-python bug with integer values

### DIFF
--- a/javascript/integration-tests/py-bug-test.js
+++ b/javascript/integration-tests/py-bug-test.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env -S node --unhandled-rejections=strict
+const Expector = require("./Expector.js");
+const { GinkInstance } = require("../tsc.out/implementation/GinkInstance.js");
+const { ensure } = require("../tsc.out/implementation/utils.js");
+
+(async () => {
+    console.log("starting");
+    const python = new Expector(
+        "python3",
+        ["-u", "-m", "gink", "-l", "*:8085"],
+        { env: { PYTHONPATH: "./python" } });
+    await python.expect("listen");
+
+    const client = new GinkInstance();
+    await client.connectTo("ws://localhost:8085");
+
+    // Error only happens when a Python instance sets an integer as a value.
+    python.send("Directory(root=True).set(3,4);\n");
+    await python.expect("Muid", 1000);
+
+    ensure(await client.getGlobalDirectory().get(3) === 4);
+
+    await python.close();
+    console.log("finished!");
+    process.exit(0);
+})().catch((reason) => { console.error(reason); process.exit(1); });

--- a/javascript/integration-tests/py-bug-test.js
+++ b/javascript/integration-tests/py-bug-test.js
@@ -14,7 +14,9 @@ const { ensure } = require("../tsc.out/implementation/utils.js");
     const client = new GinkInstance();
     await client.connectTo("ws://localhost:8085");
 
-    // Error only happens when a Python instance sets an integer as a value.
+    // This error occurs only when a typescript instance is connected to a python instance
+    // Doesn't matter whether the TS instance is a server or client.
+    // Only happens when setting an INTEGER as a VALUE. Integer keys work.
     python.send("Directory(root=True).set(3,4);\n");
     await python.expect("Muid", 1000);
 


### PR DESCRIPTION
I haven't finished the new/reworked Docker image that can test both Python and JS, so you will have to run this locally.

make clean && make
cd javascript
chmod 755 integration-tests/py-bug-test.js
./integration-tests/py-bug-test.js

This error only occurs when a typescript instance is connected to a Python instance. Whether the TS instance is server or client does not matter.
It only errors when there is an integer as a value - integer keys work fine.
Also, this only occurs when the Python instance was the one to set the integer as a value and TS is receiving it. The other way around works fine.