### PR TITLE
added sleep to make test less flaky

### DIFF
--- a/javascript/integration-tests/py-ts-test.js
+++ b/javascript/integration-tests/py-ts-test.js
@@ -12,6 +12,7 @@ const { sleep } = require("./browser_test_utilities.js");
         ["-u", "-m", "gink", "-c", "ws://localhost:8087"]);
     await client.expect("connect");
     await server.expect("accepted");
+    await sleep(100);
 
     server.send("await root.set(3,4, 'test commit');\n");
     await server.expect("received commit", 1000);


### PR DESCRIPTION
I have run the py-ts test about 15 times in the mac runner with this change and it has never failed, so I assume this is the solution to the unreliable test.