### PR TITLE
rearrange dockerfile to make it slightly more effective at caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+javascript/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN if [ `uname -m` != aarch64 ]; then apt-get update && apt-get install gnupg w
   rm -rf /var/lib/apt/lists/* && export CHROME_BIN=/usr/bin/chrome; fi
 RUN if [ `uname -m` == aarch64 ]; then apt update && apt install chromium-browser && export CHROME_BIN=/usr/bin/chromium-browser; fi
 
-ENV CWD=/opt/gink
-RUN mkdir -p $CWD
-WORKDIR $CWD
+ENV GINK=/opt/gink
+RUN mkdir -p $GINK
+WORKDIR $GINK
 COPY packages.txt ./
 COPY Makefile ./
 RUN make install-dependencies
@@ -29,18 +29,19 @@ COPY proto ./proto
 
 COPY python ./python
 RUN make python/gink/builders
-ENV PYTHONPATH $CWD/python
-WORKDIR $CWD/python
+ENV PYTHONPATH $GINK/python
+WORKDIR $GINK/python
 # Python lint
 RUN mypy gink/impl gink/tests
 
 # Python unit-tests
 RUN python3 -m nose2
 
+WORKDIR $GINK
 COPY javascript ./javascript
 RUN mv node_modules ./javascript/
 RUN make
-WORKDIR $CWD/javascript
+WORKDIR $GINK/javascript
 
 
 # JavaScript/TypeScript unit-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,7 @@
 FROM debian:latest
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update --fix-missing && apt-get upgrade -y
-ENV CWD=/opt/gink
-RUN mkdir -p $CWD
-WORKDIR $CWD
 RUN apt-get install -y make
-COPY packages.txt ./
-COPY Makefile ./
-RUN make install-dependencies
-COPY proto ./proto
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 ENV DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
@@ -23,9 +16,19 @@ RUN if [ `uname -m` != aarch64 ]; then apt-get update && apt-get install gnupg w
   rm -rf /var/lib/apt/lists/* && export CHROME_BIN=/usr/bin/chrome; fi
 RUN if [ `uname -m` == aarch64 ]; then apt update && apt install chromium-browser && export CHROME_BIN=/usr/bin/chromium-browser; fi
 
-COPY javascript ./javascript
+ENV CWD=/opt/gink
+RUN mkdir -p $CWD
+WORKDIR $CWD
+COPY packages.txt ./
+COPY Makefile ./
+RUN make install-dependencies
+COPY javascript/package.json ./
+RUN npm install && npm rebuild
+
+COPY proto ./proto
+
 COPY python ./python
-RUN make
+RUN make python/gink/builders
 ENV PYTHONPATH $CWD/python
 WORKDIR $CWD/python
 # Python lint
@@ -34,8 +37,11 @@ RUN mypy gink/impl gink/tests
 # Python unit-tests
 RUN python3 -m nose2
 
+COPY javascript ./javascript
+RUN mv node_modules ./javascript/
+RUN make
 WORKDIR $CWD/javascript
-RUN npm rebuild
+
 
 # JavaScript/TypeScript unit-tests
 RUN npm test

--- a/proto/change.proto
+++ b/proto/change.proto
@@ -4,7 +4,6 @@ import "proto/container.proto";
 import "proto/entry.proto";
 import "proto/movement.proto";
 import "proto/clearance.proto";
-import "proto/muid.proto";
 
 /**
 * Any update/change that can be referenced by Gink


### PR DESCRIPTION
The `npm install` and `npm rebuild` commands take a long time, so it's best to make them dependent only on the package.json and run them before any commands that are dependent on files likely to change (I.e. the actual project code).