### PR TITLE
allow for relative offsets

### DIFF
--- a/proto/muid.proto
+++ b/proto/muid.proto
@@ -35,5 +35,5 @@ package gink;
 message Muid {
     sint64 timestamp = 1; // microseconds since epoch
     sint64 medallion = 2; // less than 2**52, version 1 between 2**48 and 2**49, exclusive
-    uint32 offset = 3; // less than 2**20 (== 16**5)
+    sint32 offset = 3; // less than 2**20 (== 16**5)
 }

--- a/python/gink/impl/lmdb_store.py
+++ b/python/gink/impl/lmdb_store.py
@@ -833,7 +833,7 @@ class LmdbStore(AbstractStore):
             offset: int,
             builder: EntryBuilder):
         retaining = bool(decode_muts(bytes(txn.get(b"entries", db=self._retentions))))
-        ensure_entry_is_valid(builder=builder, context=new_info)
+        ensure_entry_is_valid(builder=builder, context=new_info, offset=offset)
         placement_key = Placement.from_builder(builder, new_info, offset)
         placer_muid = placement_key.placer
         container_muid = placement_key.container


### PR DESCRIPTION
The graph reset algo will require relative offsets due to how the stream of changes needs to reference newly created entries.