### PR TITLE
stop some unhandled websocket errors from crashing server

### DIFF
--- a/javascript/implementation/main.ts
+++ b/javascript/implementation/main.ts
@@ -11,3 +11,7 @@ export { CommandLineInterface };
 if (require.main === module) {
     new CommandLineInterface(process).run();
 }
+
+process.on("unhandledRejection", () => {
+    console.log("Unhandled Promise Rejection: Likely due to closed websocket connection.");
+});


### PR DESCRIPTION
This addresses issue #146 

Some "types" of disconnects/connection rejections would cause the server to crash. I'm not sure that this is the best overall solution, but this is far better than having the server crash on a closed connection.