### PR TITLE
only publish package when specific files are changed

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,6 +2,11 @@ name: Publish to NPM
 on:
   push:
     branches: [main]
+    paths:
+    - javascript/content_root/**
+    - javascript/implementation/**
+    - javascript/package.json
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,6 +3,11 @@ name: Publish Python distribution to PyPI
 on:
   push:
     branches: [main]
+    paths:
+    - python/gink/__init__.py
+    - python/gink/__main__.py
+    - python/gink/impl/**
+    - python/setup.py
 
 jobs:
   build:

--- a/.github/workflows/typescript-docs.yml
+++ b/.github/workflows/typescript-docs.yml
@@ -3,6 +3,8 @@ name: Build and Deploy Docs
 on:
   push:
     branches: [main]
+    paths:
+    - javascript/implementation/**
 
 jobs:
     build:
@@ -23,17 +25,17 @@ jobs:
     deploy:
       # Add a dependency to the build job
       needs: build
-  
+
       # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
       permissions:
         pages: write # to deploy to Pages
         id-token: write # to verify the deployment originates from an appropriate source
-  
+
       # Deploy to the github-pages environment
       environment:
         name: github-pages
         url: ${{ steps.deployment.outputs.page_url }}
-  
+
       # Specify runner + deployment step
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
We were creating a ton of versions in PyPI and npm, so this should cut down on the number of jobs for trivial commits, or commits irrelevant to ts/python.