### PR TITLE
move bundle metadata into a header to allow for header-only read

### DIFF
--- a/javascript/implementation/Bundler.ts
+++ b/javascript/implementation/Bundler.ts
@@ -1,5 +1,5 @@
 import { Muid, BundleInfo, Medallion, Timestamp, BundleView, BundleBytes } from "./typedefs";
-import { BundleBuilder, ChangeBuilder, EntryBuilder, ContainerBuilder } from "./builders";
+import { BundleBuilder, ChangeBuilder, EntryBuilder, ContainerBuilder, HeaderBuilder } from "./builders";
 import { ensure } from "./utils";
 
 export class Bundler implements BundleView {
@@ -96,11 +96,14 @@ export class Bundler implements BundleView {
         }
         this.bundleInfo = { ...bundleInfo };
         this.bundleInfo.comment = this.pendingComment;
-        this.bundleBuilder.setTimestamp(bundleInfo.timestamp);
-        this.bundleBuilder.setPrevious(bundleInfo.priorTime);
-        this.bundleBuilder.setChainStart(bundleInfo.chainStart);
-        this.bundleBuilder.setMedallion(bundleInfo.medallion);
-        this.bundleBuilder.setComment(this.bundleInfo.comment);
+        const headerBuilder = new HeaderBuilder();
+        headerBuilder.setComment(this.pendingComment);
+        headerBuilder.setTimestamp(bundleInfo.timestamp);
+        headerBuilder.setPrevious(bundleInfo.priorTime);
+        headerBuilder.setChainStart(bundleInfo.chainStart);
+        headerBuilder.setMedallion(bundleInfo.medallion);
+        headerBuilder.setComment(this.bundleInfo.comment);
+        this.bundleBuilder.setHeader(headerBuilder);
         this.bundleBytes = this.bundleBuilder.serializeBinary();
     }
 }

--- a/javascript/implementation/Database.ts
+++ b/javascript/implementation/Database.ts
@@ -20,7 +20,6 @@ import { Behavior, ChangeBuilder, ContainerBuilder, SyncMessageBuilder } from ".
 import { Property } from "./Property";
 import { Vertex } from "./Vertex";
 import { EdgeType } from "./EdgeType";
-import { BundleBuilder } from "./builders";
 import { Decomposition } from "./Decomposition";
 import { MemoryStore } from "./MemoryStore";
 

--- a/javascript/implementation/Decomposition.ts
+++ b/javascript/implementation/Decomposition.ts
@@ -1,4 +1,4 @@
-import { BundleBuilder } from "./builders";
+import { BundleBuilder, HeaderBuilder } from "./builders";
 import { BundleInfo, BundleView, Bytes } from "./typedefs";
 
 
@@ -6,13 +6,14 @@ export class Decomposition implements BundleView {
     readonly builder: BundleBuilder;
     readonly info: BundleInfo;
     constructor(readonly bytes: Bytes) {
-        const builder = this.builder = <BundleBuilder>BundleBuilder.deserializeBinary(bytes);
+        const bundleBuilder = this.builder = <BundleBuilder>BundleBuilder.deserializeBinary(bytes);
+        const headerBuilder: HeaderBuilder = bundleBuilder.getHeader();
         this.info = {
-            timestamp: builder.getTimestamp(),
-            medallion: builder.getMedallion(),
-            chainStart: builder.getChainStart(),
-            priorTime: builder.getPrevious() || undefined,
-            comment: builder.getComment() || undefined,
+            timestamp: headerBuilder.getTimestamp(),
+            medallion: headerBuilder.getMedallion(),
+            chainStart: headerBuilder.getChainStart(),
+            priorTime: headerBuilder.getPrevious() || undefined,
+            comment: headerBuilder.getComment() || undefined,
         };
     }
 }

--- a/javascript/implementation/builders.d.ts
+++ b/javascript/implementation/builders.d.ts
@@ -49,18 +49,23 @@ export class ChangeBuilder extends ImplementedMessage {
     setClearance(ClearanceBuilder);
 }
 
-export class BundleBuilder extends ImplementedMessage {
+export class HeaderBuilder extends ImplementedMessage {
     setTimestamp(number);
     setPrevious(number);
     setChainStart(number);
     setMedallion(number);
     setComment(string);
-    getChangesMap(): Map<number, ChangeBuilder>;
     getTimestamp(): number;
     getMedallion(): number;
     getChainStart(): number;
     getPrevious(): number;
     getComment(): string;
+}
+
+export class BundleBuilder extends ImplementedMessage {
+    getHeader(): HeaderBuilder;
+    setHeader(HeaderBuilder);
+    getChangesMap(): Map<number, ChangeBuilder>;
 }
 
 export class PairBuilder extends ImplementedMessage {

--- a/javascript/implementation/builders.js
+++ b/javascript/implementation/builders.js
@@ -15,6 +15,7 @@ const MuidBuilder = require("../proto/muid_pb")["Muid"];
 const KeyBuilder = require("../proto/key_pb")["Key"];
 const PairBuilder = require("../proto/pair_pb")["Pair"];
 const ValueBuilder = require("../proto/value_pb")["Value"];
+const HeaderBuilder = require("../proto/header_pb")["Header"];
 const ClearanceBuilder = require("../proto/clearance_pb")["Clearance"];
 const Special = ValueBuilder.Special;
 const NumberBuilder = ValueBuilder.Number;
@@ -23,6 +24,7 @@ const DocumentBuilder = ValueBuilder.Document;
 const TupleBuilder = ValueBuilder.Tuple;
 
 module.exports = {
+    HeaderBuilder,
     BundleBuilder,
     Behavior,
     ChangeBuilder,

--- a/javascript/unit-tests/LogBackedStore.test.ts
+++ b/javascript/unit-tests/LogBackedStore.test.ts
@@ -87,7 +87,6 @@ it('test magic', async () => {
     await store1.close();
 
     const contents = readFileSync(fn);
-    console.log(contents);
     ensure(contents[1] == 71); // G
     ensure(contents[2] == 73); // I
     ensure(contents[3] == 78); // N

--- a/javascript/unit-tests/Store.test.ts
+++ b/javascript/unit-tests/Store.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./test_utils";
 import { muidToBuilder, ensure, wrapValue, matches, wrapKey } from "../implementation/utils";
 import { Bundler, Database } from "../implementation";
+import { HeaderBuilder } from "../implementation/builders";
 // makes an empty Store for testing purposes
 export type StoreMaker = () => Promise<Store>;
 
@@ -95,17 +96,19 @@ export function testStore(implName: string, storeMaker: StoreMaker, replacer?: S
         const sent: Array<BundleBytes> = [];
         await store.getBundles((x: BundleView) => { sent.push(x.bytes); });
         expect(sent.length).toBe(4);
-        expect((<BundleBuilder>BundleBuilder.deserializeBinary(sent[0])).getTimestamp()).toBe(START_MICROS1);
-        expect((<BundleBuilder>BundleBuilder.deserializeBinary(sent[1])).getTimestamp()).toBe(START_MICROS2);
-        expect((<BundleBuilder>BundleBuilder.deserializeBinary(sent[2])).getTimestamp()).toBe(NEXT_TS1);
-        expect((<BundleBuilder>BundleBuilder.deserializeBinary(sent[3])).getTimestamp()).toBe(NEXT_TS2);
+        expect((<BundleBuilder>BundleBuilder.deserializeBinary(sent[0])).getHeader().getTimestamp()).toBe(START_MICROS1);
+        expect((<BundleBuilder>BundleBuilder.deserializeBinary(sent[1])).getHeader().getTimestamp()).toBe(START_MICROS2);
+        expect((<BundleBuilder>BundleBuilder.deserializeBinary(sent[2])).getHeader().getTimestamp()).toBe(NEXT_TS1);
+        expect((<BundleBuilder>BundleBuilder.deserializeBinary(sent[3])).getHeader().getTimestamp()).toBe(NEXT_TS2);
     });
 
     it(`${implName} test save/fetch container`, async () => {
         const bundleBuilder = new BundleBuilder();
-        bundleBuilder.setChainStart(START_MICROS1);
-        bundleBuilder.setTimestamp(START_MICROS1);
-        bundleBuilder.setMedallion(MEDALLION1);
+        const headerBuilder = new HeaderBuilder();
+        headerBuilder.setChainStart(START_MICROS1);
+        headerBuilder.setTimestamp(START_MICROS1);
+        headerBuilder.setMedallion(MEDALLION1);
+        bundleBuilder.setHeader(headerBuilder);
         const changeBuilder = new ChangeBuilder();
         const containerBuilder = new ContainerBuilder();
         containerBuilder.setBehavior(Behavior.DIRECTORY);

--- a/proto/bundle.proto
+++ b/proto/bundle.proto
@@ -1,15 +1,14 @@
 syntax = "proto3";
 import "proto/change.proto";
+import "proto/header.proto";
 package gink;
 
 message Bundle {
-    uint64 timestamp = 1;
-    uint64 medallion = 2;
-    uint64 previous = 3;
-    string comment = 4;
-    uint64 chain_start = 5;
+
+    Header header = 1;
+
     // key in changes map is the offset number: > 0 and < 2**20
-    map<uint32, Change> changes = 6;
+    map<uint32, Change> changes = 2;
 
     // I'm using a map rather than a simple repeated field of Changes for a couple of reasons:
     // * The offset of 0 is reserved to denote the transaction, and I don't want to confuse things by

--- a/proto/header.proto
+++ b/proto/header.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package gink;
+
+message Header {
+    uint64 timestamp = 1;
+    uint64 medallion = 2;
+    uint64 previous = 3;
+    string comment = 4;
+    uint64 chain_start = 5;
+}

--- a/python/gink/impl/builders.py
+++ b/python/gink/impl/builders.py
@@ -8,12 +8,13 @@ from .typedefs import Medallion, MuTimestamp
 
 if TYPE_CHECKING:
 
-    class BundleBuilder(Message):
-        pass
 
-
-    class SyncMessage(Message):
-        pass
+    class HeaderBuilder(Message):
+        timestamp: int
+        medallion: int
+        previous: int
+        comment: str
+        chain_start: int
 
 
     class ChangeBuilder(Message):
@@ -21,9 +22,20 @@ if TYPE_CHECKING:
         container: ContainerBuilder
         movement: MovementBuilder
 
+
+    class BundleBuilder(Message):
+        header: HeaderBuilder
+        changes: List[ChangeBuilder]
+
+    class SyncMessage(Message):
+        pass
+
+
+
     class Pair:
         left: MuidBuilder
         rite: MuidBuilder
+
 
     class EntryBuilder(Message):
         describing: MuidBuilder
@@ -38,25 +50,20 @@ if TYPE_CHECKING:
         key: KeyBuilder
         effective: int
 
-
     class ValueBuilder(Message):
         pass
-
 
     class KeyBuilder(Message):
         pass
 
-
     class ContainerBuilder(Message):
         behavior: int
-
 
     class MovementBuilder(Message):
         container: MuidBuilder
         entry: MuidBuilder
         dest: int
         purge: bool
-
 
     class ClearanceBuilder(Message):
         pass
@@ -75,7 +82,6 @@ if TYPE_CHECKING:
     class LogFileBuilder(Message):
         bundles: List[bytes]
         claims: List[ClaimBuilder]
-
 
     class Behavior(IntEnum):
         UNSPECIFIED = 0
@@ -105,3 +111,4 @@ else:
     from ..builders.behavior_pb2 import Behavior
     from ..builders.log_file_pb2 import LogFile as LogFileBuilder
     from ..builders.claim_pb2 import Claim as ClaimBuilder
+    from ..builders.header_pb2 import Header as HeaderBuilder

--- a/python/gink/impl/bundle_info.py
+++ b/python/gink/impl/bundle_info.py
@@ -3,7 +3,7 @@
 from typing import Optional
 from struct import Struct
 
-from .builders import SyncMessage, BundleBuilder
+from .builders import SyncMessage, HeaderBuilder
 from .typedefs import Medallion, MuTimestamp
 from .tuples import Chain
 
@@ -19,7 +19,7 @@ class BundleInfo:
     previous: MuTimestamp
     comment: str
 
-    def __init__(self, *, builder: Optional[BundleBuilder] = None, encoded: bytes = b'\x00' * 32, **kwargs):
+    def __init__(self, *, builder: Optional[HeaderBuilder] = None, encoded: bytes = b'\x00' * 32, **kwargs):
 
         if len(encoded) < 32:
             raise ValueError("need at least 32 bytes to unpack")

--- a/python/gink/impl/bundle_wrapper.py
+++ b/python/gink/impl/bundle_wrapper.py
@@ -19,5 +19,5 @@ class BundleWrapper:
 
     def get_info(self) -> BundleInfo:
         if self._bundle_info is None:
-            self._bundle_info = BundleInfo(builder=self.get_builder())
+            self._bundle_info = BundleInfo(builder=self.get_builder().header)
         return self._bundle_info

--- a/python/gink/impl/bundler.py
+++ b/python/gink/impl/bundler.py
@@ -71,12 +71,12 @@ class Bundler:
             assert timestamp == chain.chain_start
         else:
             assert chain.chain_start <= previous < timestamp
-            self._bundle_builder.previous = previous  # type: ignore
-        self._bundle_builder.chain_start = chain.chain_start  # type: ignore
-        self._medallion = self._bundle_builder.medallion = chain.medallion  # type: ignore
-        self._timestamp = self._bundle_builder.timestamp = timestamp  # type: ignore
+            self._bundle_builder.header.previous = previous  # type: ignore
+        self._bundle_builder.header.chain_start = chain.chain_start  # type: ignore
+        self._medallion = self._bundle_builder.header.medallion = chain.medallion  # type: ignore
+        self._timestamp = self._bundle_builder.header.timestamp = timestamp  # type: ignore
         if self._comment:
-            self._bundle_builder.comment = self.comment  # type: ignore
+            self._bundle_builder.header.comment = self.comment  # type: ignore
         sealed = self._bundle_builder.SerializeToString()
         self._sealed = sealed
         return sealed

--- a/python/gink/impl/database.py
+++ b/python/gink/impl/database.py
@@ -191,7 +191,7 @@ class Database:
         """ Sends a bundle either created locally or received from a peer to other peers.
         """
         outbound_message_with_bundle = SyncMessage()
-        outbound_message_with_bundle.bundle = bundle_bytes  # type: ignore
+        outbound_message_with_bundle.bundle = bundle_bytes
         for peer in self._connections:
             tracker = self._trackers.get(peer)
             if tracker is None:
@@ -210,7 +210,7 @@ class Database:
     def _receive_data(self, sync_message: SyncMessage, from_peer: Connection):
         with self._lock:
             if sync_message.HasField("bundle"):
-                bundle_bytes = sync_message.bundle  # type: ignore # pylint: disable=maybe-no-member
+                bundle_bytes = sync_message.bundle
                 wrap = BundleWrapper(bundle_bytes)
                 info = wrap.get_info()
                 if (tracker := self._trackers.get(from_peer)):
@@ -225,7 +225,7 @@ class Database:
                 def callback(bundle_bytes: bytes, info: BundleInfo):
                     if not chain_tracker.has(info):
                         outgoing_builder = SyncMessage()
-                        outgoing_builder.bundle = bundle_bytes  # type: ignore
+                        outgoing_builder.bundle = bundle_bytes
                         from_peer.send(outgoing_builder)
 
                 self._store.get_bundles(callback=callback)

--- a/python/gink/impl/lmdb_store.py
+++ b/python/gink/impl/lmdb_store.py
@@ -989,7 +989,7 @@ class LmdbStore(AbstractStore):
                 bundle_bytes = bundles_cursor.value()
                 bundle_builder = BundleBuilder()
                 bundle_builder.ParseFromString(bundle_bytes)
-                bundle_info = BundleInfo(builder=bundle_builder)
+                bundle_info = BundleInfo(builder=bundle_builder.header)
                 callback(bundle_bytes, bundle_info)
                 data_remaining = bundles_cursor.next()
 

--- a/python/gink/tests/test_store.py
+++ b/python/gink/tests/test_store.py
@@ -44,12 +44,12 @@ def install_tests(into_where, from_place, store_maker):
 def make_empty_bundle(bundle_info: BundleInfo) -> bytes:
     """ Makes an empty change set that matches the given metadata. """
     builder = BundleBuilder()
-    builder.medallion = bundle_info.medallion  # type: ignore
-    builder.chain_start = bundle_info.chain_start  # type: ignore
-    builder.timestamp = bundle_info.timestamp  # type: ignore
-    builder.previous = bundle_info.previous  # type: ignore
+    builder.header.medallion = bundle_info.medallion  # type: ignore
+    builder.header.chain_start = bundle_info.chain_start  # type: ignore
+    builder.header.timestamp = bundle_info.timestamp  # type: ignore
+    builder.header.previous = bundle_info.previous  # type: ignore
     if bundle_info.comment:
-        builder.comment = bundle_info.comment  # type: ignore
+        builder.header.comment = bundle_info.comment  # type: ignore
     return builder.SerializeToString()  # type: ignore
 
 
@@ -189,9 +189,11 @@ def generic_test_tracks(store_maker: StoreMaker):
 def generic_test_get_ordered_entries(store_maker: StoreMaker):
     """ makes sure that the get_ordered_entries works """
     textproto1 = """
-        medallion: 789
-        chain_start: 123
-        timestamp: 123
+        header {
+            medallion: 789
+            chain_start: 123
+            timestamp: 123
+        }
         changes {
             key: 1
             value {
@@ -232,10 +234,12 @@ def generic_test_get_ordered_entries(store_maker: StoreMaker):
         }
     """
     textproto2 = """
-        medallion: 789
-        chain_start: 123
-        timestamp: 234
-        previous: 123
+        header {
+            medallion: 789
+            chain_start: 123
+            timestamp: 234
+            previous: 123
+        }
         changes {
             key: 1
             value {
@@ -313,9 +317,11 @@ def generic_test_get_ordered_entries(store_maker: StoreMaker):
 def generic_test_negative_offsets(store_maker: StoreMaker):
     """ makes sure that the get_ordered_entries works """
     textproto1 = """
-        medallion: 789
-        chain_start: 123
-        timestamp: 123
+        header {
+            medallion: 789
+            chain_start: 123
+            timestamp: 123
+        }
         changes {
             key: 1
             value {


### PR DESCRIPTION
Previously all of the metadata fields were top level in the bundle proto.  This means that you might need to scan all of the bundle bytes to ensure that you had all of the header fields.  Shoving them all in a header makes it slightly easier to have a parser that can only read the header without trying to parse all of the remaining changes.