### PR TITLE
extract select loop from database.run into a separate function

### DIFF
--- a/python/gink/__main__.py
+++ b/python/gink/__main__.py
@@ -10,7 +10,7 @@ from . import *
 from .impl.builders import BundleBuilder
 from .impl.selectable_console import SelectableConsole
 from .impl.utilities import get_identity
-from .impl.looping import loop, SelectablePair
+from .impl.looping import loop
 
 parser: ArgumentParser = ArgumentParser(allow_abbrev=False)
 parser.add_argument("db_path", nargs="?", help="path to a database; created if doesn't exist")
@@ -157,4 +157,4 @@ else:
 
 console = SelectableConsole(locals(), interactive=interactive, heartbeat_to=args.heartbeat_to)
 
-loop([console, database], context_manager=console)
+loop(console, database, context_manager=console)

--- a/python/gink/__main__.py
+++ b/python/gink/__main__.py
@@ -157,7 +157,4 @@ else:
 
 console = SelectableConsole(locals(), interactive=interactive, heartbeat_to=args.heartbeat_to)
 
-loop([
-    SelectablePair(console, console.call_when_ready),
-    SelectablePair(database, database.get_selectables),
-], context_manager=console)
+loop([console, database], context_manager=console)

--- a/python/gink/impl/abstract_store.py
+++ b/python/gink/impl/abstract_store.py
@@ -29,6 +29,7 @@ class AbstractStore(BundleStore, Generic[Lock]):
         Warning! Since data stores are viewed as part of the internal implementation,
         this interface may change at any time without warning on a minor version change.
     """
+    on_ready: Callable  # needs to by dynamically assigned
 
     def __enter__(self):
         pass
@@ -39,7 +40,6 @@ class AbstractStore(BundleStore, Generic[Lock]):
     @abstractmethod
     def _get_file_path(self) -> Optional[Path]:
         """ Return the underlying file name, or None if the store isn't file backed.
-
         """
 
     def is_selectable(self) -> bool:

--- a/python/gink/impl/connection.py
+++ b/python/gink/impl/connection.py
@@ -1,5 +1,5 @@
 """ Contains the Peer class that manages a connection to another gink instance. """
-from typing import Iterable, Optional, Union
+from typing import Iterable, Optional, Union, Callable
 from socket import (
     socket as Socket,
     AF_INET,
@@ -20,12 +20,13 @@ class Connection(ABC):
         Eventually there will be two subclasses: one to manage websocket connections,
         and another subclass to manage raw socket connections.
     """
-
+    on_ready: Callable
     def __init__(
             self,
             host: Optional[str] = None,
             port: Optional[int] = None,
-            socket: Optional[Socket] = None
+            socket: Optional[Socket] = None,
+            greeting: Optional[SyncMessage] = None,
     ):
         if socket is None:
             assert host is not None and port is not None
@@ -37,6 +38,7 @@ class Connection(ABC):
         self._logger = getLogger(self.__class__.__name__)
         self._closed = False
         self._tracker: Optional[ChainTracker] = None
+        self._greeting = greeting
 
     def fileno(self):
         """ Return the file descriptor of the underlying socket.

--- a/python/gink/impl/listener.py
+++ b/python/gink/impl/listener.py
@@ -1,4 +1,5 @@
 """ contains the Listener class that listens on a port for incomming connections """
+from typing import Callable, Type
 from socket import (
     socket as Socket,
     AF_INET,
@@ -16,21 +17,26 @@ from .websocket_connection import WebsocketConnection
 class Listener:
     """ Listens on a port for incoming connections. """
 
-    def __init__(self, connection_class=WebsocketConnection, ip_addr: str = "", port: int = 8080):
-        self.connection_class = connection_class
-        self.socket = Socket(AF_INET, SOCK_STREAM)
-        self.socket.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
-        self.socket.bind((ip_addr, int(port)))
-        self.socket.listen(128)
+    on_ready: Callable  # needs to by dynamically assigned
+
+    def __init__(self, connection_class: Type[Connection]=WebsocketConnection, ip_addr: str = "", port: int = 8080):
+        self._connection_class = connection_class
+        self._socket = Socket(AF_INET, SOCK_STREAM)
+        self._socket.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+        self._socket.bind((ip_addr, int(port)))
+        self._socket.listen(128)
 
     def fileno(self):
         """ Gives the file descriptor for use in socket.select and similar. """
-        return self.socket.fileno()
+        return self._socket.fileno()
+
+    def close(self):
+        self._socket.close()
 
     def accept(self, greeting: SyncMessage) -> Connection:
         """ Method to call when the underlying socket is "ready". """
-        (new_socket, addr) = self.socket.accept()
-        peer: Connection = self.connection_class(
+        (new_socket, addr) = self._socket.accept()
+        peer: Connection = self._connection_class(
             socket=new_socket,
             host=addr[0],
             port=addr[1],

--- a/python/gink/impl/looping.py
+++ b/python/gink/impl/looping.py
@@ -26,9 +26,10 @@ class Selectable(Protocol):
 def loop(
         *selectables: Selectable,
         context_manager: ContextManager = nullcontext(),
-        selector: BaseSelector = DefaultSelector(),
+        selector: Optional[BaseSelector] = None,
         until: GenericTimestamp = None,
         ) -> None:
+    selector = selector or DefaultSelector()
     registered: Set[Selectable] = set()
     until_muts = None if until is None else resolve_timestamp(until)
 

--- a/python/gink/impl/looping.py
+++ b/python/gink/impl/looping.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from typing import *
+from selectors import DefaultSelector
+from contextlib import nullcontext
+
+class Finished(BaseException):
+    """ Thrown when FileObj is done receiving data and should be removed from selectable set and closed. """
+    pass
+
+
+class FileObj(Protocol):
+
+    def fileno(self) -> int:
+        """ return the underlying filehandle """
+
+    def close(self):
+        """ close the file object """
+
+FileObjType = TypeVar('FileObjType', FileObj)
+
+
+class SelectablePair(NamedTuple, Generic[FileObjType]):
+    fileobj: FileObjType
+    callback: Callable[[FileObjType], Optional[Iterable[SelectablePair]]]
+
+def loop(
+        pairs: Iterable[SelectablePair],
+        context_manager = nullcontext(),
+        ) -> None:
+    for fileobj, callback in pairs:
+        pass
+    with context_manager:
+        pass

--- a/python/gink/impl/looping.py
+++ b/python/gink/impl/looping.py
@@ -3,6 +3,9 @@ from typing import *
 from selectors import DefaultSelector, BaseSelector, EVENT_READ
 from contextlib import nullcontext
 
+from .utilities import GenericTimestamp, resolve_timestamp, generate_timestamp
+
+
 class Finished(BaseException):
     """ Thrown when FileObj is done receiving data and should be removed from selectable set and closed. """
     pass
@@ -21,29 +24,40 @@ class Selectable(Protocol):
 
 
 def loop(
-        selectables: Iterable[Selectable],
+        *selectables: Iterable[Selectable],
         context_manager: ContextManager = nullcontext(),
         selector: BaseSelector = DefaultSelector(),
+        until: GenericTimestamp = None,
         ) -> None:
     registered: Set[Selectable] = set()
+    until_muts = None if until is None else resolve_timestamp(until)
 
     def add(_selectables):
         for selectable in _selectables:
             if selectable and selectable not in registered:
                 selector.register(selectable, EVENT_READ)
+                registered.add(selectable)
 
+    add(selectables)
     with context_manager:
-        add(selectables)
-        for selector_key, _ in selector.select(0.1):
-            selectable = cast(Selectable, selector_key.fileobj)
+        while until_muts is None or generate_timestamp() < until_muts:
             try:
-                results = selectable.on_ready()
-                if results:
-                    add(results)
-            except Finished:
-                selector.unregister(selectable)
-                selectable.close()
-        else:
-            for selectable in registered:
-                if hasattr(selectable, "on_timeout"):
-                    selectable.on_timeout()
+                selected = selector.select(0.1)
+            except KeyboardInterrupt:
+                break
+            for selector_key, _ in selected:
+                selectable = cast(Selectable, selector_key.fileobj)
+                try:
+                    results = selectable.on_ready()
+                    if results:
+                        add(results)
+                except Finished:
+                    selector.unregister(selectable)
+                    selectable.close()
+                    registered.remove(selectable)
+            else:
+                for selectable in registered:
+                    if hasattr(selectable, "on_timeout"):
+                        selectable.on_timeout()
+        for selectable in registered:
+            selector.unregister(selectable)

--- a/python/gink/impl/looping.py
+++ b/python/gink/impl/looping.py
@@ -24,7 +24,7 @@ class Selectable(Protocol):
 
 
 def loop(
-        *selectables: Iterable[Selectable],
+        *selectables: Selectable,
         context_manager: ContextManager = nullcontext(),
         selector: BaseSelector = DefaultSelector(),
         until: GenericTimestamp = None,

--- a/python/gink/impl/selectable_console.py
+++ b/python/gink/impl/selectable_console.py
@@ -51,7 +51,7 @@ class SelectableConsole(InteractiveInterpreter):
         ioctl(self.fileno(), FIONREAD, self._c_int)  # type: ignore
         return self._c_int.value
 
-    def call_when_ready(self):
+    def call_when_ready(self, *_):
         try:
             if self._interactive:
                 for _ in range(self._bytes_available()):

--- a/python/gink/impl/selectable_console.py
+++ b/python/gink/impl/selectable_console.py
@@ -51,7 +51,7 @@ class SelectableConsole(InteractiveInterpreter):
         ioctl(self.fileno(), FIONREAD, self._c_int)  # type: ignore
         return self._c_int.value
 
-    def call_when_ready(self, *_):
+    def on_ready(self):
         try:
             if self._interactive:
                 for _ in range(self._bytes_available()):
@@ -68,7 +68,7 @@ class SelectableConsole(InteractiveInterpreter):
         if result is True:
             self._logger.warning("multi-line input not yet implemented")
 
-    def refresh(self):
+    def on_timeout(self):
         if self._interactive:
             data = self._prompt + "".join(self._buffer)
             self._output.write("\r" + data + " ")

--- a/python/gink/impl/utilities.py
+++ b/python/gink/impl/utilities.py
@@ -65,7 +65,6 @@ def experimental(thing):
                 DeprecationWarning, stacklevel=2,)
             warned[0] = True
         return thing(*a, **b)
-
     if the_class:
         the_class.__init__ = wrapped
         return the_class

--- a/python/gink/impl/utilities.py
+++ b/python/gink/impl/utilities.py
@@ -93,7 +93,7 @@ def resolve_timestamp(timestamp: GenericTimestamp) -> MuTimestamp:
             timestamp = int(timestamp)
         else:
             timestamp = datetime.fromisoformat(timestamp)
-    if hasattr(timestamp, "timestamp"):
+    if timestamp is not None and hasattr(timestamp, "timestamp"):
         muid_timestamp = timestamp.timestamp
         if not isinstance(muid_timestamp, MuTimestamp):
             raise ValueError("timestamp.timestamp doesn't have a resolved timestamp")

--- a/python/gink/impl/utilities.py
+++ b/python/gink/impl/utilities.py
@@ -8,8 +8,10 @@ from functools import wraps
 from warnings import warn
 from random import randint
 from platform import system
+from datetime import datetime, date, timedelta
+from re import fullmatch, IGNORECASE
 
-from .typedefs import MuTimestamp, Medallion
+from .typedefs import MuTimestamp, Medallion, GenericTimestamp
 from .tuples import Chain
 from .builders import ClaimBuilder
 
@@ -84,3 +86,31 @@ def create_claim(chain: Chain) -> ClaimBuilder:
     claim_builder.chain_start = chain.chain_start
     claim_builder.process_id = getpid()
     return claim_builder
+
+def resolve_timestamp(timestamp: GenericTimestamp) -> MuTimestamp:
+    if isinstance(timestamp, str):
+        if fullmatch(r"-?\d+", timestamp):
+            timestamp = int(timestamp)
+        else:
+            timestamp = datetime.fromisoformat(timestamp)
+    if hasattr(timestamp, "timestamp"):
+        muid_timestamp = timestamp.timestamp
+        if not isinstance(muid_timestamp, MuTimestamp):
+            raise ValueError("timestamp.timestamp doesn't have a resolved timestamp")
+        return muid_timestamp
+    if isinstance(timestamp, timedelta):
+        return generate_timestamp() + int(timestamp.total_seconds() * 1e6)
+    if isinstance(timestamp, date):
+        timestamp = datetime(timestamp.year, timestamp.month, timestamp.day)
+    if isinstance(timestamp, datetime):
+        timestamp = timestamp.timestamp()
+    if isinstance(timestamp, (int, float)):
+        if 1671697316392367 < timestamp < 2147483648000000:
+            # appears to be a microsecond timestamp
+            return int(timestamp)
+        if 1671697630 < timestamp < 2147483648:
+            # appears to be seconds since epoch
+            return int(timestamp * 1e6)
+    if isinstance(timestamp, float) and 1e6 > timestamp > -1e6:
+        return generate_timestamp() + int(1e6 * timestamp)
+    raise ValueError(f"don't know how to resolve {timestamp} into a timestamp")

--- a/python/gink/impl/websocket_connection.py
+++ b/python/gink/impl/websocket_connection.py
@@ -48,7 +48,7 @@ class WebsocketConnection(Connection):
             path: Optional[str] = None,
             greeting: Optional[SyncMessage] = None
     ):
-        Connection.__init__(self, socket=socket, host=host, port=port)
+        Connection.__init__(self, socket=socket, host=host, port=port, greeting=greeting)
         if socket is None:
             force_to_be_client = True
         connection_type = ConnectionType.CLIENT if force_to_be_client else ConnectionType.SERVER
@@ -69,7 +69,7 @@ class WebsocketConnection(Connection):
             self._socket.send(self._ws.send(request))
         self._logger.debug("finished setup")
         self._socket.settimeout(0.2)
-        self._greeting = greeting
+
 
     def __repr__(self):
         return f"{self.__class__.__name__}(host={self._host!r})"

--- a/python/gink/impl/wsgi_connection.py
+++ b/python/gink/impl/wsgi_connection.py
@@ -1,5 +1,9 @@
 """ One connection to a WsgiListener """
 from socket import socket as Socket
+from io import StringIO
+from sys import stderr
+from datetime import datetime
+from typing import Iterable, Optional, Dict, Any
 
 class WsgiConnection(object):
     def __init__(self, socket: Socket):
@@ -21,3 +25,69 @@ class WsgiConnection(object):
         except ConnectionResetError as e:
             request_data = None
         return request_data
+
+
+    def get_environ(self, request_data, request_method, path) -> Dict[str, Any]:
+        return {
+            'wsgi.version':  (1, 0),
+            'wsgi.url_scheme': 'http',
+            'wsgi.input': StringIO(request_data),
+            'wsgi.errors': stderr,
+            'wsgi.multithread': False,
+            'wsgi.multiprocess': False,
+            'wsgi.run_once': False,
+            'REQUEST_METHOD': request_method,
+            'PATH_INFO': path,
+            'SERVER_NAME': self._server_name,
+            'SERVER_PORT': str(self._server_port)
+        }
+
+    def start_response(self, status, response_headers, exc_info: Optional[tuple]=None):
+        server_headers = [
+            ('Date', datetime.now()),
+            ('Server', 'WSGIServer 0.2'),
+        ]
+
+        # If headers have already been sent
+        if exc_info and self._headers_set:
+            raise exc_info[1].with_traceback(exc_info[2])
+
+        self._headers_set = [status, response_headers + server_headers]
+
+        return self.write
+
+    def write(self, _: str):
+            raise NotImplementedError("Using the write callable has not been implemented.")
+
+    def finish_response(self, result: Iterable[bytes], conn: WsgiConnection):
+        status, response_headers = self._headers_set
+        response = f'HTTP/1.0 {status}\r\n'
+        for header in response_headers:
+            response += '{0}: {1}\r\n'.format(*header)
+        response += '\r\n'
+        for data in result:
+            if isinstance(data, bytes):
+                response += data.decode('utf-8')
+            else:
+                response += data
+        if self._logger:
+            self._logger.debug(f'HTTP/1.0 {status}')
+        response_bytes = response.encode()
+        conn.sendall(response_bytes)
+
+    def process_request(self, request_data: Optional[bytes]):
+        """
+        Holds all of the request processing that does not involve a connection.
+        The result from this method will need to be passed to finish_response along
+        with the connection.
+        """
+        if not request_data:
+            return False
+        decoded = request_data.decode('utf-8')
+        lines = decoded.splitlines()
+        if self._logger:
+            self._logger.debug(''.join(f'< {line}\n' for line in lines))
+        (request_method, path, _) = lines[0].split(maxsplit=3)
+        env = self.get_environ(decoded, request_method, path)
+        result = self._app(env, self.start_response)
+        return result

--- a/python/gink/impl/wsgi_connection.py
+++ b/python/gink/impl/wsgi_connection.py
@@ -3,31 +3,50 @@ from socket import socket as Socket
 from io import StringIO
 from sys import stderr
 from datetime import datetime
-from typing import Iterable, Optional, Dict, Any
+from typing import Iterable, Optional, Dict, Any, List
+from logging import getLogger
 
-class WsgiConnection(object):
-    def __init__(self, socket: Socket):
-        self.sock = socket
-        self.fd = socket.fileno()
+from .looping import Selectable, Finished
+
+class WsgiConnection(Selectable):
+
+    def __init__(self, app, socket: Socket, server_name: str, server_port: int):
+        self._app = app
+        self._socket = socket
+        self._fd = socket.fileno()
+        self._logger = getLogger(self.__class__.__name__)
+        self._server_name = server_name
+        self._server_port = server_port
+        self._response_headers: Optional[List[tuple]] = None
+        self._status: Optional[str] = None
+        self._response_started = False
 
     def fileno(self):
-        return self.fd
+        return self._fd
 
     def close(self):
-        self.sock.close()
+        self._socket.close()
 
-    def sendall(self, data: bytes):
-        self.sock.sendall(data)
-
-    def receive_data(self):
+    def on_ready(self) -> None:
         try:
-            request_data = self.sock.recv(1024)
-        except ConnectionResetError as e:
-            request_data = None
-        return request_data
+            request_data = self._socket.recv(1024)
+        except ConnectionResetError:
+            raise Finished()
+        decoded = request_data.decode('utf-8')
+        lines = decoded.splitlines()
+        if self._logger:
+            self._logger.debug(''.join(f'< {line}\n' for line in lines))
+        (request_method, path, _) = lines[0].split(maxsplit=3)
+        env = self._get_environ(decoded, request_method, path)
+        result: Iterable[bytes] = self._app(env, self._start_response)
+        for data in result:
+            if data:
+                self._write(data)
+        if not self._response_started:
+            self._write(b"")
+        raise Finished()  # will cause the loop to call close after deregistering
 
-
-    def get_environ(self, request_data, request_method, path) -> Dict[str, Any]:
+    def _get_environ(self, request_data, request_method, path) -> Dict[str, Any]:
         return {
             'wsgi.version':  (1, 0),
             'wsgi.url_scheme': 'http',
@@ -39,55 +58,29 @@ class WsgiConnection(object):
             'REQUEST_METHOD': request_method,
             'PATH_INFO': path,
             'SERVER_NAME': self._server_name,
-            'SERVER_PORT': str(self._server_port)
+            'SERVER_PORT': str(self._server_port),
         }
 
-    def start_response(self, status, response_headers, exc_info: Optional[tuple]=None):
-        server_headers = [
+    def _start_response(self, status: str, response_headers: List[tuple], exc_info: Optional[tuple]=None):
+        server_headers: List[tuple] = [
             ('Date', datetime.now()),
             ('Server', 'WSGIServer 0.2'),
         ]
-
-        # If headers have already been sent
-        if exc_info and self._headers_set:
+        if exc_info and self._response_started:
             raise exc_info[1].with_traceback(exc_info[2])
+        self._status = status
+        self._response_headers = response_headers + server_headers
+        return self._write
 
-        self._headers_set = [status, response_headers + server_headers]
-
-        return self.write
-
-    def write(self, _: str):
-            raise NotImplementedError("Using the write callable has not been implemented.")
-
-    def finish_response(self, result: Iterable[bytes], conn: WsgiConnection):
-        status, response_headers = self._headers_set
-        response = f'HTTP/1.0 {status}\r\n'
-        for header in response_headers:
-            response += '{0}: {1}\r\n'.format(*header)
-        response += '\r\n'
-        for data in result:
-            if isinstance(data, bytes):
-                response += data.decode('utf-8')
-            else:
-                response += data
-        if self._logger:
-            self._logger.debug(f'HTTP/1.0 {status}')
-        response_bytes = response.encode()
-        conn.sendall(response_bytes)
-
-    def process_request(self, request_data: Optional[bytes]):
-        """
-        Holds all of the request processing that does not involve a connection.
-        The result from this method will need to be passed to finish_response along
-        with the connection.
-        """
-        if not request_data:
-            return False
-        decoded = request_data.decode('utf-8')
-        lines = decoded.splitlines()
-        if self._logger:
-            self._logger.debug(''.join(f'< {line}\n' for line in lines))
-        (request_method, path, _) = lines[0].split(maxsplit=3)
-        env = self.get_environ(decoded, request_method, path)
-        result = self._app(env, self.start_response)
-        return result
+    def _write(self, blob: bytes):
+        if self._status is None:
+            raise ValueError("write before start_response")
+        if not self._response_started:
+            response = f'HTTP/1.0 {self._status}\r\n'
+            assert self._response_headers is not None
+            for header in self._response_headers:
+                response += '{0}: {1}\r\n'.format(*header)
+            response += '\r\n'
+            self._socket.sendall(response.encode())
+            self._response_started = True
+        self._socket.sendall(blob)

--- a/python/gink/impl/wsgi_listener.py
+++ b/python/gink/impl/wsgi_listener.py
@@ -16,7 +16,7 @@ class WsgiListener(Selectable):
     socket_type = SOCK_STREAM
     request_queue_size = 1024
 
-    def __init__(self, app, address: tuple = ('localhost', 8081)):
+    def __init__(self, app, ip_addr: str = "", port: int = 8081):
         # app would be the equivalent of a Flask app, or other WSGI compatible application
         app_args = getfullargspec(app).args
         assert "environ" in app_args and "start_response" in app_args, "Application is not WSGI compatible"
@@ -28,9 +28,9 @@ class WsgiListener(Selectable):
 
         self._socket.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
         self._socket.setblocking(False)
-        self._socket.bind(address)
+        self._socket.bind((ip_addr, port))
         self._socket.listen(self.request_queue_size)
-        self._logger.info(f"Web server listening on port {address[1]}")
+        self._logger.info(f"Web server listening on interface: '{ip_addr}' port {port}")
 
         host, port = self._socket.getsockname()[:2]
         self._server_name = getfqdn(host)

--- a/python/gink/impl/wsgi_listener.py
+++ b/python/gink/impl/wsgi_listener.py
@@ -5,10 +5,6 @@ The point of this class is to integrate within the Database select loop.
 
 from socket import socket as Socket, SOL_SOCKET, SO_REUSEADDR, getfqdn, AF_INET, SOCK_STREAM
 from inspect import getfullargspec
-from io import StringIO
-from sys import stderr
-from datetime import datetime
-from typing import Iterable, Optional
 from errno import EINTR
 from logging import getLogger
 
@@ -40,10 +36,10 @@ class WsgiListener():
         self._server_port = port
         self._headers_set: list[str] = []
 
-    def fileno(self):
+    def fileno(self) -> int:
         return self._fd
 
-    def accept(self):
+    def accept(self) -> WsgiConnection:
         try:
             conn, _ = self._socket.accept()
         except BlockingIOError as e:
@@ -53,68 +49,3 @@ class WsgiListener():
             else:
                 raise e
         return WsgiConnection(conn)
-
-    def get_environ(self, request_data, request_method, path):
-        return {
-            'wsgi.version':  (1, 0),
-            'wsgi.url_scheme': 'http',
-            'wsgi.input': StringIO(request_data),
-            'wsgi.errors': stderr,
-            'wsgi.multithread': False,
-            'wsgi.multiprocess': False,
-            'wsgi.run_once': False,
-            'REQUEST_METHOD': request_method,
-            'PATH_INFO': path,
-            'SERVER_NAME': self._server_name,
-            'SERVER_PORT': str(self._server_port)
-        }
-
-    def start_response(self, status, response_headers, exc_info: Optional[tuple]=None):
-        server_headers = [
-            ('Date', datetime.now()),
-            ('Server', 'WSGIServer 0.2'),
-        ]
-
-        # If headers have already been sent
-        if exc_info and self._headers_set:
-            raise exc_info[1].with_traceback(exc_info[2])
-
-        self._headers_set = [status, response_headers + server_headers]
-
-        return self.write
-
-    def write(self, _: str):
-            raise NotImplementedError("Using the write callable has not been implemented.")
-
-    def finish_response(self, result: Iterable[bytes], conn: WsgiConnection):
-        status, response_headers = self._headers_set
-        response = f'HTTP/1.0 {status}\r\n'
-        for header in response_headers:
-            response += '{0}: {1}\r\n'.format(*header)
-        response += '\r\n'
-        for data in result:
-            if isinstance(data, bytes):
-                response += data.decode('utf-8')
-            else:
-                response += data
-        if self._logger:
-            self._logger.debug(f'HTTP/1.0 {status}')
-        response_bytes = response.encode()
-        conn.sendall(response_bytes)
-
-    def process_request(self, request_data: Optional[bytes]):
-        """
-        Holds all of the request processing that does not involve a connection.
-        The result from this method will need to be passed to finish_response along
-        with the connection.
-        """
-        if not request_data:
-            return False
-        decoded = request_data.decode('utf-8')
-        lines = decoded.splitlines()
-        if self._logger:
-            self._logger.debug(''.join(f'< {line}\n' for line in lines))
-        (request_method, path, _) = lines[0].split(maxsplit=3)
-        env = self.get_environ(decoded, request_method, path)
-        result = self._app(env, self.start_response)
-        return result

--- a/python/gink/impl/wsgi_listener.py
+++ b/python/gink/impl/wsgi_listener.py
@@ -17,21 +17,15 @@ class WsgiListener(Selectable):
     request_queue_size = 1024
 
     def __init__(self, app, ip_addr: str = "", port: int = 8081):
-        # app would be the equivalent of a Flask app, or other WSGI compatible application
-        app_args = getfullargspec(app).args
-        assert "environ" in app_args and "start_response" in app_args, "Application is not WSGI compatible"
         self._app = app
-
         self._socket = Socket(self.address_family, self.socket_type)
         self._fd = self._socket.fileno()
         self._logger = getLogger(self.__class__.__name__)
-
         self._socket.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
         self._socket.setblocking(False)
         self._socket.bind((ip_addr, port))
         self._socket.listen(self.request_queue_size)
         self._logger.info(f"Web server listening on interface: '{ip_addr}' port {port}")
-
         host, port = self._socket.getsockname()[:2]
         self._server_name = getfqdn(host)
         self._server_port = port

--- a/python/gink/impl/wsgi_listener.py
+++ b/python/gink/impl/wsgi_listener.py
@@ -4,7 +4,6 @@ The point of this class is to integrate within the Database select loop.
 """
 
 from socket import socket as Socket, SOL_SOCKET, SO_REUSEADDR, getfqdn, AF_INET, SOCK_STREAM
-from inspect import getfullargspec
 from logging import getLogger
 from typing import Iterable
 
@@ -41,3 +40,6 @@ class WsgiListener(Selectable):
             socket=socket,
             server_name=self._server_name,
             server_port=self._server_port)
+
+    def close(self):
+        self._socket.close()

--- a/python/gink/tests/test_database.py
+++ b/python/gink/tests/test_database.py
@@ -14,6 +14,7 @@ from ..impl.directory import Directory
 from ..impl.sequence import Sequence
 from ..impl.key_set import KeySet
 from ..impl.log_backed_store import LogBackedStore
+from ..impl.looping import loop
 
 
 def test_database():
@@ -123,11 +124,11 @@ def test_react_to_store_changes():
         root1a = Directory(arche=True, database=db1a)
         root1b = Directory(arche=True, database=db1b)
 
-        db1b.run(0.01)
+        loop(db1b, until=.01)
         bundle_infos = list()
         db1b.add_callback(lambda bi: bundle_infos.append(bi))
         root1a.set("foo", "bar", comment="abc")
-        db1b.run(0.01)
+        loop(db1b, until=.01)
         assert bundle_infos and bundle_infos[-1].comment == "abc"
         found = root1b.get("foo")
         assert found == "bar", found

--- a/python/gink/tests/test_websocket_connection.py
+++ b/python/gink/tests/test_websocket_connection.py
@@ -8,7 +8,7 @@ import os
 from ..impl.builders import SyncMessage
 from google.protobuf.text_format import Parse  # type: ignore
 
-from ..impl.websocket_connection import WebsocketConnection
+from ..impl.websocket_connection import WebsocketConnection, Finished
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -52,8 +52,11 @@ def test_chit_chat():
             assert incoming == message, incoming
 
     client.close()
-    for _ in server.receive():
-        raise Exception("not expected")
+    try:
+        for _ in server.receive():
+            raise Exception("not expected")
+    except Finished:
+        server.close()
 
     assert client.is_closed() and server.is_closed()
 

--- a/python/gink/tests/test_wsgi_server.py
+++ b/python/gink/tests/test_wsgi_server.py
@@ -4,18 +4,18 @@ and the endpoints will be reachable as expected.
 """
 import requests
 from flask import Flask
-from multiprocessing import Process
+from multiprocessing import Process, set_start_method
 
 from ..impl.wsgi_listener import WsgiListener
 from ..impl.looping import loop
 
+set_start_method("fork")  # flask can't be pickled
 
 def wsgi_app(_, start_response):
     status = '200 OK'
     headers = [('Content-type', 'text/html')]
     start_response(status, headers)
     return [b'<h1 id="test">Hello universe!</h1>']
-
 
 def test_wsgi_integration():
     flask_app = Flask(__name__)

--- a/python/gink/tests/test_wsgi_server.py
+++ b/python/gink/tests/test_wsgi_server.py
@@ -4,40 +4,43 @@ and the endpoints will be reachable as expected.
 """
 import requests
 from flask import Flask
-import multiprocessing
+from multiprocessing import Process
 
 from ..impl.wsgi_listener import WsgiListener
 from ..impl.looping import loop
 
+
+def wsgi_app(_, start_response):
+    status = '200 OK'
+    headers = [('Content-type', 'text/html')]
+    start_response(status, headers)
+    return [b'<h1 id="test">Hello universe!</h1>']
+
+
 def test_wsgi_integration():
-    multiprocessing.set_start_method("fork")
-    # Flask Server
     flask_app = Flask(__name__)
+
     @flask_app.route('/hello')
-    def hello_world():
+    def _():
         return '<h1 id="test">Hello World</h1>'
-
-    # Default WSGI complient application
-    def wsgi_app(environ, start_response):
-        status = '200 OK'
-        headers = [('Content-type', 'text/html')]
-        start_response(status, headers)
-        return [b'<h1 id="test">Hello universe!</h1>']
-
 
     flask_wrapper = WsgiListener(flask_app, port=8081)
     basic_wrapper = WsgiListener(wsgi_app, port=8082)
 
-    p = multiprocessing.Process(target=flask_wrapper.run)
-    p.start()
-    p2 = multiprocessing.Process(target=wsgi_db.run)
+    p1 = Process(target=loop, args=[flask_wrapper])
+    p1.start()
+    p2 = Process(target=loop, args=[basic_wrapper])
     p2.start()
 
     try:
-        data = requests.get("http://localhost:8081/hello").text
+        data1 = requests.get("http://localhost:8081/hello").text
         data2 = requests.get("http://localhost:8082").text
-        assert "Hello World" in data
+        assert "Hello World" in data1
         assert "Hello universe!" in data2
     finally:
-        p.terminate()
+        p1.terminate()
         p2.terminate()
+
+
+if __name__ == "__main__":
+    loop(WsgiListener(wsgi_app))


### PR DESCRIPTION
In order to support the braid server (which will effectively require two databases running at the same time) I've pulled out the select loop from the database run method into a free standing `loop` utility function.  It takes something that implements a new `Selectable` protocol (interface), which has a `fileno` method and an `on_ready` method.  In order to facilitate the use case of listening sockets adding new connections, the `on_ready` is allowed to return more selectables to add to the loop.