### PR TITLE
edit dockerfile to run tests on raspberry pi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,8 @@ RUN apt-get install -y make unzip curl
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 ENV DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
 
-# Install Google Chrome Stable and fonts
-# Note: this installs the necessary libs to make the browser work with Puppeteer.
-RUN if [ `uname -m` != aarch64 ]; then apt-get update && apt-get install gnupg wget -y && \
-  wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
-  sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
-  apt-get update && \
-  apt-get install google-chrome-stable -y --no-install-recommends && \
-  rm -rf /var/lib/apt/lists/* && export CHROME_BIN=/usr/bin/chrome; fi
-RUN if [ `uname -m` == aarch64 ]; then apt update && apt install chromium-browser && export CHROME_BIN=/usr/bin/chromium-browser; fi
+RUN apt-get update && apt-get install -y chromium
+ENV CHROME_BIN=/usr/bin/chromium
 
 ENV GINK=/opt/gink
 RUN mkdir -p $GINK
@@ -46,7 +39,7 @@ WORKDIR $GINK/javascript
 RUN npm test
 RUN npm run browser-unit
 
-# Python integration tests
+# # Python integration tests
 RUN ./integration-tests/py-py-test.js
 RUN ./integration-tests/py-ts-test.js
 RUN ./integration-tests/ts-py-test.js


### PR DESCRIPTION
There were a couple reasons why this wasn't working on the pi. One of which is chromium-browser doesn't exist for ARM, but the `chromium` package works on my pi and wsl/debian.

Feel free to pull this and try to build the image yourself. It is working on my Pi 5.