### PR TITLE
fixed issue causing npm downloaded gink to break in browser

### DIFF
--- a/javascript/implementation/index.ts
+++ b/javascript/implementation/index.ts
@@ -1,6 +1,4 @@
 export { Database } from "./Database";
-export { RoutingServer } from "./RoutingServer";
-export { RoutingServerInstance } from "./RoutingServerInstance";
 export { Box } from "./Box";
 export { Directory } from "./Directory";
 export { Sequence } from "./Sequence";

--- a/javascript/implementation/main.ts
+++ b/javascript/implementation/main.ts
@@ -4,6 +4,7 @@ export * from "./index";
 export { LogBackedStore } from "./LogBackedStore";
 export { SimpleServer } from "./SimpleServer";
 export { RoutingServer } from "./RoutingServer";
+export { RoutingServerInstance } from "./RoutingServerInstance";
 import { CommandLineInterface } from "./CommandLineInterface";
 export { CommandLineInterface };
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -2,7 +2,7 @@
   "name": "@x5e/gink",
   "version": "${VERSION}",
   "description": "an eventually consistent database",
-  "main": "tsc.out/implementation/main.js",
+  "main": "tsc.out/implementation/index.js",
   "browser": {
     "@x5e/gink": "content_root/generated/packed.js",
     "fs": false,


### PR DESCRIPTION
I removed any exports that are not needed on the client side from the index.ts file. These exports happen in main.ts instead.

Part of what was happening was, when the user writes something like `import { Database } from "@x5e/gink"`, it would resolve the import to  @x5e/gink/tsc.out/implementation/main.js, which is really not ideal for the client side. By changing "main" in the package.json to `tsc.out/implementation/index.js`, referring to `@x5e/gink` while importing will resolve to `@x5e/gink/tsc.out/implementation/index.js`.