### PR TITLE
fix npm publish action

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,11 +1,11 @@
 name: Publish to NPM
-on: [push]
-  # push:
-    # branches: [main]
-    # paths:
-    # - javascript/content_root/**
-    # - javascript/implementation/**
-    # - javascript/package.json
+on:
+  push:
+    branches: [main]
+    paths:
+    - javascript/content_root/**
+    - javascript/implementation/**
+    - javascript/package.json
 
 jobs:
   build:
@@ -31,7 +31,7 @@ jobs:
         run: cd .. && make javascript
       - name: Update Version
         run: export VERSION=`date -u +0.%Y%m%d.%s` && sed -i "s/\${VERSION}/${VERSION}/g" package.json
-      # - name: Publish package on NPM
-      #   run: npm publish --access public
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish package on NPM
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,11 +1,11 @@
 name: Publish to NPM
-on:
-  push:
+on: [push]
+  # push:
     # branches: [main]
-    paths:
-    - javascript/content_root/**
-    - javascript/implementation/**
-    - javascript/package.json
+    # paths:
+    # - javascript/content_root/**
+    # - javascript/implementation/**
+    # - javascript/package.json
 
 jobs:
   build:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,7 +1,7 @@
 name: Publish to NPM
 on:
   push:
-    branches: [main]
+    # branches: [main]
     paths:
     - javascript/content_root/**
     - javascript/implementation/**
@@ -15,23 +15,23 @@ jobs:
         working-directory: ./javascript
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Protobuf Compiler
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: protobuf-compiler
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: npm ci && npm rebuild
       - name: Build Protos
         run: cd .. && make javascript
-      - name: Rebuild
-        run: npm rebuild
       - name: Update Version
         run: export VERSION=`date -u +0.%Y%m%d.%s` && sed -i "s/\${VERSION}/${VERSION}/g" package.json
-      - name: Publish package on NPM
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # - name: Publish package on NPM
+      #   run: npm publish --access public
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Looks like we weren't installing any node modules in the npm publish action from when I changed to npm ci.

Also it was using a deprecated node version.