### PR TITLE
check for container in clearance and speed up receive bundle

### DIFF
--- a/javascript/unit-tests/Database.test.ts
+++ b/javascript/unit-tests/Database.test.ts
@@ -47,6 +47,9 @@ it('test listeners', async () => {
 
         ensure(globalDirListener.calledTimes == 1);
         ensure(allContainersListener.calledTimes == 3);
+
+        await globalDir.clear();
+        ensure(globalDirListener.calledTimes == 2);
     }
 });
 


### PR DESCRIPTION
I was previously looping through each change in a change map to create a list of containers, then sending the bundle info to the listeners subscribed to that container. That works, but for some reason I wasn't checking to see if there actually were any listeners... this will definitely speed something up.

Also fixed an issue where a container clearance wouldn't call the container specific listener.