### PR TITLE
explicitly start a chain

### DIFF
--- a/javascript/implementation/Database.ts
+++ b/javascript/implementation/Database.ts
@@ -26,7 +26,7 @@ import { MemoryStore } from "./MemoryStore";
 /**
  * This is an instance of the Gink database that can be run inside a web browser or via
  * ts-node on a server.  Because of the need to work within a browser it doesn't do any port
- * listening (see GinkListener and GinkServerInstance for that capability).
+ * listening (see SimpleServer for that capability).
  */
 export class Database {
 
@@ -34,7 +34,7 @@ export class Database {
     readonly peers: Map<number, Peer> = new Map();
     static readonly PROTOCOL = "gink";
 
-    private listeners: Map<string, BundleListener[]> = new Map();
+    private listeners: Map<string, Map<string, BundleListener[]>> = new Map();
     private countConnections = 0; // Includes disconnected clients.
     private myChain: ClaimedChain;
     private identity: string;
@@ -53,16 +53,19 @@ export class Database {
 
     private async initialize(): Promise<void> {
         await this.store.ready;
-
         this.iHave = await this.store.getChainTracker();
-        this.listeners.set("all", []);
-        //this.logger(`Database.ready`);
+
+        const innerMap = new Map();
+        innerMap.set("all_bundles", []);
+        innerMap.set("remote_only", []);
+        this.listeners.set("all", innerMap);
+
         const callback = async (bundle: BundleView): Promise<void> => {
             for (const [peerId, peer] of this.peers) {
                 peer._sendIfNeeded(bundle);
             }
             // Send to listeners subscribed to all containers.
-            for (const listener of this.listeners.get("all")) {
+            for (const listener of this.getListeners()) {
                 listener(bundle.info);
             }
         };
@@ -249,12 +252,29 @@ export class Database {
     * @param listener a callback to be invoked when a change occurs in the database or container
     * @param containerMuid the Muid of a container to subscribe to. If left out, subscribe to all containers.
     */
-    public addListener(listener: BundleListener, containerMuid?: Muid) {
+    public addListener(listener: BundleListener, containerMuid?: Muid, remoteOnly: boolean = false) {
         const key = containerMuid ? muidToString(containerMuid) : "all";
         if (!this.listeners.has(key)) {
-            this.listeners.set(key, []);
+            const innerMap = new Map();
+            innerMap.set("all_bundles", []);
+            innerMap.set("remote_only", []);
+            this.listeners.set(key, innerMap);
         }
-        this.listeners.get(key).push(listener);
+        const which = remoteOnly ? "remote_only" : "all_bundles";
+        this.listeners.get(key).get(which).push(listener);
+    }
+
+    /**
+    * Gets a list of bundle listeners per container, listening to all bundles or just remote.
+    * @param remoteOnly true if looking for listeners only subscribed to remote bundles.
+    * @param containerMuid optional container muid to find listeners subscribed to a specific container.
+    */
+    private getListeners(remoteOnly: boolean = false, containerMuid?: Muid): BundleListener[] {
+        const key = containerMuid ? muidToString(containerMuid) : "all";
+        const containerMap = this.listeners.get(key);
+        if (!containerMap) return [];
+        const innerMap = remoteOnly ? containerMap.get("remote_only") : containerMap.get("all_bundles");
+        return innerMap || [];
     }
 
     /**
@@ -330,13 +350,13 @@ export class Database {
                     peer._sendIfNeeded(bundle);
             }
             // Send to listeners subscribed to all containers.
-            for (const listener of this.listeners.get("all")) {
+            for (const listener of this.getListeners()) {
                 listener(bundle.info);
             }
 
             if (this.listeners.size > 1) {
                 // Loop through changes and gather a set of changed containers.
-                const changedContainers: Set<string> = new Set();
+                const changedContainers: Set<Muid> = new Set();
                 const changesMap: Map<Offset, ChangeBuilder> = bundle.builder.getChangesMap();
                 for (const [offset, changeBuilder] of changesMap.entries()) {
                     const entry = changeBuilder.getEntry();
@@ -357,16 +377,19 @@ export class Database {
                                 offset: offset
                             }
                         );
-                        const stringMuid = muidToString(muid);
-                        changedContainers.add(stringMuid);
+                        changedContainers.add(muid);
                     }
                 }
                 // Send to listeners specifically subscribed to each container.
-                for (const strMuid of changedContainers) {
-                    const containerListeners = this.listeners.get(strMuid);
-                    if (containerListeners) {
-                        for (const listener of containerListeners) {
-                            listener(bundle.info);
+                for (const muid of changedContainers) {
+                    const containerListeners = this.getListeners(false, muid);
+                    const remoteOnlyListeners = this.getListeners(true, muid);
+                    for (const listener of containerListeners) {
+                        listener(bundle.info);
+                    }
+                    if (fromConnectionId) {
+                        for (const remoteListener of remoteOnlyListeners) {
+                            remoteListener(bundle.info);
                         }
                     }
                 }

--- a/javascript/implementation/Database.ts
+++ b/javascript/implementation/Database.ts
@@ -116,7 +116,7 @@ export class Database {
 
     /**
      * Either returns the existing chain, or starts a new one and returns that.
-     * Useful if you need to explicitly start a chain without actually committing any data.
+     * Useful if you need to explicitly start a chain without committing an entry to a container.
      * @returns a new or existing ClaimedChain
      */
     public async getOrStartChain(): Promise<ClaimedChain> {

--- a/javascript/integration-tests/remote-listener-test.js
+++ b/javascript/integration-tests/remote-listener-test.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S node --unhandled-rejections=strict
+const Expector = require("./Expector.js");
+const { Database, ensure } = require("../tsc.out/implementation/index.js");
+const { sleep } = require("./browser_test_utilities.js");
+process.chdir(__dirname + "/..");
+
+(async () => {
+    console.log("starting remote listener test");
+    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: "9090", ...process.env } }, false);
+    await server.expect("ready", 2000);
+
+    const client1 = new Database();
+    await client1.connectTo("ws://localhost:9090");
+    const client2 = new Database();
+    await client2.connectTo("ws://localhost:9090");
+
+    await sleep(200);
+    console.log("connections established");
+
+    const remoteListener = (x, y) => {
+        remoteListener.calledTimes++;
+    };
+    remoteListener.calledTimes = 0;
+
+    const client1Root = client1.getGlobalDirectory();
+    const client2Root = client2.getGlobalDirectory();
+
+    // Add a remote only listener
+    client1.addListener(remoteListener, client1Root.address, true);
+
+    await client1Root.set("1", "2");
+    ensure(remoteListener.calledTimes == 0);
+    // Should not have been called, since client1 is only subscribed to remote changes
+
+    await client2Root.set("2", "3");
+    await sleep(200);
+    ensure(remoteListener.calledTimes == 1);
+    // Only subscribed to remote changes, so a remote bundle should call the listener
+    console.log("correctly called listener only on remote bundle. finished!");
+
+    await client1.close();
+    await client2.close();
+    await server.close();
+
+})();

--- a/javascript/unit-tests/Database.test.ts
+++ b/javascript/unit-tests/Database.test.ts
@@ -1,4 +1,5 @@
 import { Database, IndexedDbStore, Bundler, MemoryStore } from "../implementation";
+import { SimpleServer } from "../implementation/SimpleServer";
 import { ensure } from "../implementation/utils";
 
 it('test bundle', async () => {
@@ -21,35 +22,35 @@ it('test listeners', async () => {
         new MemoryStore(true),
     ]) {
         await store.ready;
-        const instance = new Database(store);
-        await instance.ready;
+        const db = new Database(store);
+        await db.ready;
 
-        const globalDir = instance.getGlobalDirectory();
-        const sequence = await instance.createSequence();
-        const box = await instance.createBox();
+        const root = db.getGlobalDirectory();
+        const sequence = await db.createSequence();
+        const box = await db.createBox();
 
-        const globalDirListener = async () => {
-            globalDirListener.calledTimes++;
+        const rootListener = async () => {
+            rootListener.calledTimes++;
         };
-        globalDirListener.calledTimes = 0;
+        rootListener.calledTimes = 0;
 
         const allContainersListener = async () => {
             allContainersListener.calledTimes++;
         };
         allContainersListener.calledTimes = 0;
 
-        instance.addListener(globalDirListener, globalDir.address);
-        instance.addListener(allContainersListener);
+        db.addListener(rootListener, root.address);
+        db.addListener(allContainersListener);
 
-        await globalDir.set("foo", "bar");
+        await root.set("foo", "bar");
         await sequence.push("foo");
         await box.set("test");
 
-        ensure(globalDirListener.calledTimes == 1);
+        ensure(rootListener.calledTimes == 1);
         ensure(allContainersListener.calledTimes == 3);
 
-        await globalDir.clear();
-        ensure(globalDirListener.calledTimes == 2);
+        await root.clear();
+        ensure(rootListener.calledTimes == 2);
     }
 });
 


### PR DESCRIPTION
This was something that stood out as an inconvenience while using gink. The use case I ran into was where I needed to detect if a change was from my own instance (same medallion). Here's how I did that before this change (maybe there is an easier way):
![Screenshot 2024-06-09 at 4 30 19 PM](https://github.com/x5e/gink/assets/48377460/5b9e8718-e270-4ea7-b921-646896b199bc)
And heres now:
```ts
const chain = await db.getOrStartChain();
```