### PR TITLE
bundle listeners can now be subscribed to only remote bundles

### DIFF
--- a/javascript/implementation/Database.ts
+++ b/javascript/implementation/Database.ts
@@ -274,8 +274,6 @@ export class Database {
     }
 
     /**
-    * NOTE: "all" is a valid containerId for the purpose of this operation.
-    * Otherwise, the containerId should be the muid as a string.
     * Gets a list of bundle listeners per container, listening to all bundles or just remote.
     * @param remoteOnly true if looking for listeners only subscribed to remote bundles.
     * @param containerMuid optional container muid to find listeners subscribed to a specific container.

--- a/javascript/integration-tests/remote-listener-test.js
+++ b/javascript/integration-tests/remote-listener-test.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S node --unhandled-rejections=strict
+const Expector = require("./Expector.js");
+const { Database, ensure } = require("../tsc.out/implementation/index.js");
+const { sleep } = require("./browser_test_utilities.js");
+process.chdir(__dirname + "/..");
+
+(async () => {
+    console.log("starting remote listener test");
+    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: "9090", ...process.env } }, false);
+    await server.expect("ready", 2000);
+
+    const client1 = new Database();
+    await client1.connectTo("ws://localhost:9090");
+    const client2 = new Database();
+    await client2.connectTo("ws://localhost:9090");
+
+    await sleep(200);
+    console.log("connections established");
+
+    const remoteListener = (x, y) => {
+        remoteListener.calledTimes++;
+    };
+    remoteListener.calledTimes = 0;
+
+    const client1Root = client1.getGlobalDirectory();
+    const client2Root = client2.getGlobalDirectory();
+
+    // Add a remote only listener
+    client1.addListener(remoteListener, client1Root.address, true);
+
+    await client1Root.set("1", "2");
+    ensure(remoteListener.calledTimes == 0);
+    // Should not have been called, since client1 is only subscribed to remote changes
+
+    await client2Root.set("2", "3");
+    await sleep(200);
+    ensure(remoteListener.calledTimes == 1);
+    // Only subscribed to remote changes, so a remote bundle should call the listener
+    console.log("correctly called listener only on remote bundle. finished!");
+
+    await client1.close();
+    await client2.close();
+    await server.close();
+
+})();

--- a/javascript/unit-tests/Database.test.ts
+++ b/javascript/unit-tests/Database.test.ts
@@ -1,4 +1,5 @@
 import { Database, IndexedDbStore, Bundler, MemoryStore } from "../implementation";
+import { SimpleServer } from "../implementation/SimpleServer";
 import { ensure } from "../implementation/utils";
 
 it('test bundle', async () => {
@@ -21,35 +22,35 @@ it('test listeners', async () => {
         new MemoryStore(true),
     ]) {
         await store.ready;
-        const instance = new Database(store);
-        await instance.ready;
+        const db = new Database(store);
+        await db.ready;
 
-        const globalDir = instance.getGlobalDirectory();
-        const sequence = await instance.createSequence();
-        const box = await instance.createBox();
+        const root = db.getGlobalDirectory();
+        const sequence = await db.createSequence();
+        const box = await db.createBox();
 
-        const globalDirListener = async () => {
-            globalDirListener.calledTimes++;
+        const rootListener = async () => {
+            rootListener.calledTimes++;
         };
-        globalDirListener.calledTimes = 0;
+        rootListener.calledTimes = 0;
 
         const allContainersListener = async () => {
             allContainersListener.calledTimes++;
         };
         allContainersListener.calledTimes = 0;
 
-        instance.addListener(globalDirListener, globalDir.address);
-        instance.addListener(allContainersListener);
+        db.addListener(rootListener, root.address);
+        db.addListener(allContainersListener);
 
-        await globalDir.set("foo", "bar");
+        await root.set("foo", "bar");
         await sequence.push("foo");
         await box.set("test");
 
-        ensure(globalDirListener.calledTimes == 1);
+        ensure(rootListener.calledTimes == 1);
         ensure(allContainersListener.calledTimes == 3);
 
-        await globalDir.clear();
-        ensure(globalDirListener.calledTimes == 2);
+        await root.clear();
+        ensure(rootListener.calledTimes == 2);
     }
 });
 


### PR DESCRIPTION
While working with gink on the demo, I found myself REALLY wanting a way to differentiate between local and remote commits. I figured out a workaround, but it isn't super pretty and I think this makes the interface much easier to use. The bundle listener will be a VERY commonly used feature, since applications will need to update accordingly when synchronizing between instances.