### PR TITLE
integration tests now use an increasing port number to ensure they don't overlap.

### DIFF
--- a/javascript/integration-tests/authentication-test.js
+++ b/javascript/integration-tests/authentication-test.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector");
-const { getSafePort } = require("./browser_test_utilities");
 process.chdir(__dirname + "/..");
 
 (async () => {
-    const port = getSafePort();
+    const port = process.env.CURRENT_SAFE_PORT;
     console.log("starting");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, GINK_TOKEN: "abc", ...process.env } });
     await server.expect("ready", 2000);

--- a/javascript/integration-tests/authentication-test.js
+++ b/javascript/integration-tests/authentication-test.js
@@ -1,19 +1,22 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector");
+const { getSafePort } = require("./browser_test_utilities");
 process.chdir(__dirname + "/..");
+
 (async () => {
+    const port = getSafePort();
     console.log("starting");
-    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: "8090", GINK_TOKEN: "abc", ...process.env } });
+    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, GINK_TOKEN: "abc", ...process.env } });
     await server.expect("ready", 2000);
     const client = new Expector("./tsc.out/implementation/main.js");
     await client.expect("node.gink", 2000);
     console.log("all ready");
 
-    client.send("await database.connectTo('ws://127.0.0.1:8090').catch((err)=>console.error('unable to connect'));\n");
+    client.send(`await database.connectTo('ws://127.0.0.1:${port}').catch((err)=>console.error('unable to connect'));\n`);
     await client.expect("unable to connect", 2000);
     console.log("saw rejection");
 
-    client.send("await database.connectTo('ws://127.0.0.1:8090', {authToken:'abc'}).catch((err)=>console.error(err, 'unable to connect'));\n");
+    client.send(`await database.connectTo('ws://127.0.0.1:${port}', {authToken:'abc'}).catch((err)=>console.error(err, 'unable to connect'));\n`);
     await server.expect("Connection accepted.", 2000);
     console.log("correct token accepted");
 

--- a/javascript/integration-tests/authentication-test.js
+++ b/javascript/integration-tests/authentication-test.js
@@ -3,7 +3,7 @@ const Expector = require("./Expector");
 process.chdir(__dirname + "/..");
 
 (async () => {
-    const port = process.env.CURRENT_SAFE_PORT;
+    const port = process.env.CURRENT_SAFE_PORT ?? 8080 ?? 8080;
     console.log("starting");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, GINK_TOKEN: "abc", ...process.env } });
     await server.expect("ready", 2000);

--- a/javascript/integration-tests/authentication-test.js
+++ b/javascript/integration-tests/authentication-test.js
@@ -3,7 +3,7 @@ const Expector = require("./Expector");
 process.chdir(__dirname + "/..");
 
 (async () => {
-    const port = process.env.CURRENT_SAFE_PORT ?? 8080 ?? 8080;
+    const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     console.log("starting");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, GINK_TOKEN: "abc", ...process.env } });
     await server.expect("ready", 2000);

--- a/javascript/integration-tests/browser-client-test/browser.test.js
+++ b/javascript/integration-tests/browser-client-test/browser.test.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 const Expector = require("../Expector");
 const { expect } = require('@jest/globals');
-const { getLaunchOptions, sleep } = require("../browser_test_utilities");
+const { getLaunchOptions, sleep, getSafePort } = require("../browser_test_utilities");
 
 it('connect to server and display bundles', async () => {
     let browser = await puppeteer.launch(getLaunchOptions());
@@ -9,7 +9,7 @@ it('connect to server and display bundles', async () => {
     let page = await browser.newPage();
 
     const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-        { env: { GINK_PORT: "8082", GINK_STATIC_PATH: ".", ...process.env } },
+        { env: { GINK_PORT: getSafePort(), GINK_STATIC_PATH: ".", ...process.env } },
         false);
     await sleep(1000);
     await server.expect("ready");

--- a/javascript/integration-tests/browser-client-test/browser.test.js
+++ b/javascript/integration-tests/browser-client-test/browser.test.js
@@ -1,36 +1,40 @@
 const puppeteer = require('puppeteer');
 const Expector = require("../Expector");
 const { expect } = require('@jest/globals');
-const { getLaunchOptions, sleep, getSafePort } = require("../browser_test_utilities");
+const { getLaunchOptions, sleep } = require("../browser_test_utilities");
 
 it('connect to server and display bundles', async () => {
-    let browser = await puppeteer.launch(getLaunchOptions());
+    const port = 9997;
+    try {
+        let browser = await puppeteer.launch(getLaunchOptions());
+        let page = await browser.newPage();
 
-    let page = await browser.newPage();
+        const server = new Expector("node", ["./tsc.out/implementation/main.js"],
+            { env: { GINK_PORT: port, GINK_STATIC_PATH: ".", ...process.env } },
+            false);
+        await sleep(1000);
+        await server.expect("ready");
 
-    const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-        { env: { GINK_PORT: getSafePort(), GINK_STATIC_PATH: ".", ...process.env } },
-        false);
-    await sleep(1000);
-    await server.expect("ready");
+        // For some reason if I don't handle console output, this test fails because
+        // the messages aren't displayed properly..?
+        // TODO: Figure out why the test fails without page.on('console')
+        page.on('console', async e => {
+            const args = await Promise.all(e.args().map(a => a.jsonValue()));
+        });
 
-    // For some reason if I don't handle console output, this test fails because
-    // the messages aren't displayed properly..?
-    // TODO: Figure out why the test fails without page.on('console')
-    page.on('console', async e => {
-        const args = await Promise.all(e.args().map(a => a.jsonValue()));
-    });
+        await page.goto(`http://127.0.0.1:${port}/integration-tests/browser-client-test/index.html`);
+        await page.waitForSelector('#messages');
 
-    await page.goto('http://127.0.0.1:8082/integration-tests/browser-client-test/index.html');
-    await page.waitForSelector('#messages');
+        await sleep(4000);
 
-    await sleep(4000);
+        const messages = await page.$eval("#messages", e => e.innerHTML);
 
-    const messages = await page.$eval("#messages", e => e.innerHTML);
-
-    await server.close();
-    await browser.close();
-
-    const expectedMessages = /Messages go here\..*Hello, Universe!.*/s;
-    expect(messages).toMatch(expectedMessages);
+        const expectedMessages = /Messages go here\..*Hello, Universe!.*/s;
+        expect(messages).toMatch(expectedMessages);
+    } catch (e) {
+        throw new Error(e);
+    } finally {
+        await server.close();
+        await browser.close();
+    }
 }, 40000);

--- a/javascript/integration-tests/browser-client-test/browser.test.js
+++ b/javascript/integration-tests/browser-client-test/browser.test.js
@@ -5,15 +5,15 @@ const { getLaunchOptions, sleep } = require("../browser_test_utilities");
 
 it('connect to server and display bundles', async () => {
     const port = 9997;
+    const server = new Expector("node", ["./tsc.out/implementation/main.js"],
+        { env: { GINK_PORT: port, GINK_STATIC_PATH: ".", ...process.env } },
+        false);
+    let browser = await puppeteer.launch(getLaunchOptions());
     try {
-        let browser = await puppeteer.launch(getLaunchOptions());
-        let page = await browser.newPage();
-
-        const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-            { env: { GINK_PORT: port, GINK_STATIC_PATH: ".", ...process.env } },
-            false);
         await sleep(1000);
         await server.expect("ready");
+
+        let page = await browser.newPage();
 
         // For some reason if I don't handle console output, this test fails because
         // the messages aren't displayed properly..?

--- a/javascript/integration-tests/browser_test_utilities.js
+++ b/javascript/integration-tests/browser_test_utilities.js
@@ -32,11 +32,17 @@ function getLaunchOptions(headless = true) {
     return launchOptions;
 };
 
+let currentPort = 8080;
+function getSafePort() {
+    return `${currentPort++}`;
+}
+
 async function sleep(ms) {
     return new Promise(r => setTimeout(r, ms));
 };
 
 module.exports = {
     getLaunchOptions: getLaunchOptions,
-    sleep: sleep
+    sleep: sleep,
+    getSafePort: getSafePort
 };

--- a/javascript/integration-tests/browser_test_utilities.js
+++ b/javascript/integration-tests/browser_test_utilities.js
@@ -32,17 +32,11 @@ function getLaunchOptions(headless = true) {
     return launchOptions;
 };
 
-let currentPort = 8080;
-function getSafePort() {
-    return `${currentPort++}`;
-}
-
 async function sleep(ms) {
     return new Promise(r => setTimeout(r, ms));
 };
 
 module.exports = {
     getLaunchOptions: getLaunchOptions,
-    sleep: sleep,
-    getSafePort: getSafePort
+    sleep: sleep
 };

--- a/javascript/integration-tests/chain-reuse-ts-test.js
+++ b/javascript/integration-tests/chain-reuse-ts-test.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector");
-const { Database } = require("../tsc.out/implementation/Database.js");
-const { LogBackedStore } = require("../tsc.out/implementation/LogBackedStore.js");
 const { existsSync, unlinkSync } = require('fs');
 const { sleep } = require('./browser_test_utilities.js');
 const TEST_DB_PATH = "/tmp/chain-reuse-ts-test.db";

--- a/javascript/integration-tests/chain-reuse-ts-test.js
+++ b/javascript/integration-tests/chain-reuse-ts-test.js
@@ -44,8 +44,6 @@ process.chdir(__dirname + "/..");
     await sleep(100);
     await instance2.close();
 
-
-
     process.exit(0);
 })().catch(async (reason) => {
     console.error(reason);

--- a/javascript/integration-tests/dashboard.test.js
+++ b/javascript/integration-tests/dashboard.test.js
@@ -1,14 +1,15 @@
 const puppeteer = require('puppeteer');
 const Expector = require("./Expector");
 const { expect } = require('@jest/globals');
-const { getLaunchOptions, sleep } = require("./browser_test_utilities");
+const { getLaunchOptions, sleep, getSafePort } = require("./browser_test_utilities");
 process.chdir(__dirname + "/..");
 it('connect to server and display dashboard', async () => {
+    const port = getSafePort();
     let browser = await puppeteer.launch(getLaunchOptions()); // pass false to getLaunchOptions for local debugging.
     let page = await browser.newPage();
 
     const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-        { env: { GINK_PORT: "8083", ...process.env } },
+        { env: { GINK_PORT: port, ...process.env } },
         false);
     await sleep(1000);
     await server.expect("ready");
@@ -17,7 +18,7 @@ it('connect to server and display dashboard', async () => {
         const args = await Promise.all(e.args().map(a => a.jsonValue()));
     });
 
-    await page.goto(`http://localhost:8083/`);
+    await page.goto(`http://localhost:${port}/`);
     await page.waitForSelector('#root');
 
     await sleep(4000);
@@ -47,19 +48,20 @@ it('share bundles between two pages', async () => {
      * that can both send bundles and have them reflected in the other
      * page.
      */
+    const port = getSafePort();
     let browser = await puppeteer.launch(getLaunchOptions()); // pass false to getLaunchOptions for local debugging.
     let page1 = await browser.newPage();
     let page2 = await browser.newPage();
     const pages = [page1, page2];
 
     const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-        { env: { GINK_PORT: "8084", ...process.env } });
+        { env: { GINK_PORT: port, ...process.env } });
     await sleep(1000);
     await server.expect("ready");
 
     try {
         for (const page of pages) {
-            await page.goto(`http://localhost:8084/`);
+            await page.goto(`http://localhost:${port}/`);
             await page.waitForSelector('#root');
 
             page.on('dialog', async dialog => {

--- a/javascript/integration-tests/dashboard.test.js
+++ b/javascript/integration-tests/dashboard.test.js
@@ -5,15 +5,15 @@ const { getLaunchOptions, sleep } = require("./browser_test_utilities");
 process.chdir(__dirname + "/..");
 it('connect to server and display dashboard', async () => {
     const port = 9998;
-    try {
-        let browser = await puppeteer.launch(getLaunchOptions()); // pass false to getLaunchOptions for local debugging.
-        let page = await browser.newPage();
+    const server = new Expector("node", ["./tsc.out/implementation/main.js"],
+        { env: { GINK_PORT: port, ...process.env } },
+        false);
+    let browser = await puppeteer.launch(getLaunchOptions()); // pass false to getLaunchOptions for local debugging.
 
-        const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-            { env: { GINK_PORT: port, ...process.env } },
-            false);
+    try {
         await sleep(1000);
         await server.expect("ready");
+        let page = await browser.newPage();
 
         page.on('console', async e => {
             const args = await Promise.all(e.args().map(a => a.jsonValue()));
@@ -49,16 +49,16 @@ it('share bundles between two pages', async () => {
      * page.
      */
     const port = 9999;
+    const server = new Expector("node", ["./tsc.out/implementation/main.js"],
+        { env: { GINK_PORT: port, ...process.env } }, false);
+    let browser = await puppeteer.launch(getLaunchOptions()); // pass false to getLaunchOptions for local debugging.
     try {
-        let browser = await puppeteer.launch(getLaunchOptions()); // pass false to getLaunchOptions for local debugging.
+        await sleep(1000);
+        await server.expect("ready");
+
         let page1 = await browser.newPage();
         let page2 = await browser.newPage();
         const pages = [page1, page2];
-
-        const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-            { env: { GINK_PORT: port, ...process.env } });
-        await sleep(1000);
-        await server.expect("ready");
 
         for (const page of pages) {
             await page.goto(`http://localhost:${port}/`);

--- a/javascript/integration-tests/dashboard.test.js
+++ b/javascript/integration-tests/dashboard.test.js
@@ -1,38 +1,38 @@
 const puppeteer = require('puppeteer');
 const Expector = require("./Expector");
 const { expect } = require('@jest/globals');
-const { getLaunchOptions, sleep, getSafePort } = require("./browser_test_utilities");
+const { getLaunchOptions, sleep } = require("./browser_test_utilities");
 process.chdir(__dirname + "/..");
 it('connect to server and display dashboard', async () => {
-    const port = getSafePort();
-    let browser = await puppeteer.launch(getLaunchOptions()); // pass false to getLaunchOptions for local debugging.
-    let page = await browser.newPage();
-
-    const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-        { env: { GINK_PORT: port, ...process.env } },
-        false);
-    await sleep(1000);
-    await server.expect("ready");
-
-    page.on('console', async e => {
-        const args = await Promise.all(e.args().map(a => a.jsonValue()));
-    });
-
-    await page.goto(`http://localhost:${port}/`);
-    await page.waitForSelector('#root');
-
-    await sleep(4000);
-
-    const title = await page.$eval("#title-bar", e => e.innerHTML);
-    expect(title).toMatch("Root Directory");
-
-    await page.reload();
-    await server.expect("disconnected.");
-
-    await sleep(4000);
-
-    // Make sure server does not crash after page reload.
+    const port = 9998;
     try {
+        let browser = await puppeteer.launch(getLaunchOptions()); // pass false to getLaunchOptions for local debugging.
+        let page = await browser.newPage();
+
+        const server = new Expector("node", ["./tsc.out/implementation/main.js"],
+            { env: { GINK_PORT: port, ...process.env } },
+            false);
+        await sleep(1000);
+        await server.expect("ready");
+
+        page.on('console', async e => {
+            const args = await Promise.all(e.args().map(a => a.jsonValue()));
+        });
+
+        await page.goto(`http://localhost:${port}/`);
+        await page.waitForSelector('#root');
+
+        await sleep(4000);
+
+        const title = await page.$eval("#title-bar", e => e.innerHTML);
+        expect(title).toMatch("Root Directory");
+
+        await page.reload();
+        await server.expect("disconnected.");
+
+        await sleep(4000);
+
+        // Make sure server does not crash after page reload.
         await server.expect("got greeting from 2");
     } catch (e) {
         throw new Error(e);
@@ -48,18 +48,18 @@ it('share bundles between two pages', async () => {
      * that can both send bundles and have them reflected in the other
      * page.
      */
-    const port = getSafePort();
-    let browser = await puppeteer.launch(getLaunchOptions()); // pass false to getLaunchOptions for local debugging.
-    let page1 = await browser.newPage();
-    let page2 = await browser.newPage();
-    const pages = [page1, page2];
-
-    const server = new Expector("node", ["./tsc.out/implementation/main.js"],
-        { env: { GINK_PORT: port, ...process.env } });
-    await sleep(1000);
-    await server.expect("ready");
-
+    const port = 9999;
     try {
+        let browser = await puppeteer.launch(getLaunchOptions()); // pass false to getLaunchOptions for local debugging.
+        let page1 = await browser.newPage();
+        let page2 = await browser.newPage();
+        const pages = [page1, page2];
+
+        const server = new Expector("node", ["./tsc.out/implementation/main.js"],
+            { env: { GINK_PORT: port, ...process.env } });
+        await sleep(1000);
+        await server.expect("ready");
+
         for (const page of pages) {
             await page.goto(`http://localhost:${port}/`);
             await page.waitForSelector('#root');

--- a/javascript/integration-tests/logbacked-peers-test.js
+++ b/javascript/integration-tests/logbacked-peers-test.js
@@ -2,6 +2,7 @@
 const Expector = require("./Expector");
 const { Database } = require("../tsc.out/implementation/Database.js");
 const { LogBackedStore } = require("../tsc.out/implementation/LogBackedStore.js");
+const { getSafePort } = require("./browser_test_utilities.js");
 /*
 Logbacked1 <- Share File -> Logbacked2
                                 v
@@ -12,8 +13,9 @@ automatically pull the changes and broadcast them.
 */
 process.chdir(__dirname + "/..");
 (async () => {
+    const port = getSafePort();
     console.log("starting");
-    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: "8082", ...process.env } });
+    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } });
     await server.expect("listening", 10000);
     console.log("server started");
 
@@ -24,7 +26,7 @@ process.chdir(__dirname + "/..");
     const lbstore2 = new LogBackedStore("/tmp/test_peer.store");
     const instance2 = new Database(lbstore2);
     await instance2.ready;
-    await instance2.connectTo("ws://localhost:8082");
+    await instance2.connectTo(`ws://localhost:${port}`);
     console.log("second store connected to server");
 
     await instance1.getGlobalDirectory().set("foo", "bar", "testing peer callback");

--- a/javascript/integration-tests/logbacked-peers-test.js
+++ b/javascript/integration-tests/logbacked-peers-test.js
@@ -12,7 +12,7 @@ automatically pull the changes and broadcast them.
 */
 process.chdir(__dirname + "/..");
 (async () => {
-    const port = process.env.CURRENT_SAFE_PORT;
+    const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     console.log("starting");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } });
     await server.expect("listening", 10000);

--- a/javascript/integration-tests/logbacked-peers-test.js
+++ b/javascript/integration-tests/logbacked-peers-test.js
@@ -2,7 +2,6 @@
 const Expector = require("./Expector");
 const { Database } = require("../tsc.out/implementation/Database.js");
 const { LogBackedStore } = require("../tsc.out/implementation/LogBackedStore.js");
-const { getSafePort } = require("./browser_test_utilities.js");
 /*
 Logbacked1 <- Share File -> Logbacked2
                                 v
@@ -13,7 +12,7 @@ automatically pull the changes and broadcast them.
 */
 process.chdir(__dirname + "/..");
 (async () => {
-    const port = getSafePort();
+    const port = process.env.CURRENT_SAFE_PORT;
     console.log("starting");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } });
     await server.expect("listening", 10000);

--- a/javascript/integration-tests/node-client-test.js
+++ b/javascript/integration-tests/node-client-test.js
@@ -2,7 +2,7 @@
 const Expector = require("./Expector");
 process.chdir(__dirname + "/..");
 (async () => {
-    const port = process.env.CURRENT_SAFE_PORT;
+    const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     console.log("starting");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } });
     await server.expect("listening", 10000);

--- a/javascript/integration-tests/node-client-test.js
+++ b/javascript/integration-tests/node-client-test.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector");
+const { getSafePort } = require("./browser_test_utilities");
 process.chdir(__dirname + "/..");
 (async () => {
+    const port = getSafePort();
     console.log("starting");
-    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: "8085", ...process.env } });
+    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } });
     await server.expect("listening", 10000);
-    const client = new Expector("./tsc.out/implementation/main.js", ["ws://127.0.0.1:8085/"]);
+    const client = new Expector("./tsc.out/implementation/main.js", [`ws://127.0.0.1:${port}/`]);
     await client.expect("using", 10000);
     console.log("all ready");
 

--- a/javascript/integration-tests/node-client-test.js
+++ b/javascript/integration-tests/node-client-test.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector");
-const { getSafePort } = require("./browser_test_utilities");
 process.chdir(__dirname + "/..");
 (async () => {
-    const port = getSafePort();
+    const port = process.env.CURRENT_SAFE_PORT;
     console.log("starting");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } });
     await server.expect("listening", 10000);

--- a/javascript/integration-tests/py-py-test.js
+++ b/javascript/integration-tests/py-py-test.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector.js");
-const { sleep, getSafePort } = require("./browser_test_utilities.js");
+const { sleep } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 (async () => {
-    const port = getSafePort();
+    const port = process.env.CURRENT_SAFE_PORT;
     console.log("starting");
     const server = new Expector(
         "python3",

--- a/javascript/integration-tests/py-py-test.js
+++ b/javascript/integration-tests/py-py-test.js
@@ -3,7 +3,7 @@ const Expector = require("./Expector.js");
 const { sleep } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 (async () => {
-    const port = process.env.CURRENT_SAFE_PORT;
+    const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     console.log("starting");
     const server = new Expector(
         "python3",

--- a/javascript/integration-tests/py-py-test.js
+++ b/javascript/integration-tests/py-py-test.js
@@ -1,18 +1,19 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector.js");
-const { sleep } = require("./browser_test_utilities.js");
+const { sleep, getSafePort } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 (async () => {
+    const port = getSafePort();
     console.log("starting");
     const server = new Expector(
         "python3",
-        ["-u", "-m", "gink", "-l", "*:8086"]
+        ["-u", "-m", "gink", "-l", `*:${port}`]
     );
     await server.expect("listen", 2000);
 
     const client = new Expector(
         "python3",
-        ["-u", "-m", "gink", "-c", "ws://localhost:8086"]
+        ["-u", "-m", "gink", "-c", `ws://localhost:${port}`]
     );
     await client.expect("connect", 2000);
     await server.expect("accepted", 2000);

--- a/javascript/integration-tests/py-ts-test.js
+++ b/javascript/integration-tests/py-ts-test.js
@@ -1,16 +1,17 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector.js");
-const { sleep } = require("./browser_test_utilities.js");
+const { sleep, getSafePort } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 
 (async () => {
+    const port = getSafePort();
     console.log("starting");
-    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: "8087", ...process.env } });
+    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } });
     await server.expect("ready", 2000);
 
     const client = new Expector(
         "python3",
-        ["-u", "-m", "gink", "-c", "ws://localhost:8087"]);
+        ["-u", "-m", "gink", "-c", `ws://localhost:${port}`]);
     await client.expect("connect");
     await server.expect("accepted");
     await sleep(100);

--- a/javascript/integration-tests/py-ts-test.js
+++ b/javascript/integration-tests/py-ts-test.js
@@ -4,7 +4,7 @@ const { sleep } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 
 (async () => {
-    const port = process.env.CURRENT_SAFE_PORT;
+    const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     console.log("starting");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } });
     await server.expect("ready", 2000);

--- a/javascript/integration-tests/py-ts-test.js
+++ b/javascript/integration-tests/py-ts-test.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector.js");
-const { sleep, getSafePort } = require("./browser_test_utilities.js");
+const { sleep } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 
 (async () => {
-    const port = getSafePort();
+    const port = process.env.CURRENT_SAFE_PORT;
     console.log("starting");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } });
     await server.expect("ready", 2000);

--- a/javascript/integration-tests/remote-listener-test.js
+++ b/javascript/integration-tests/remote-listener-test.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector.js");
 const { Database, ensure } = require("../tsc.out/implementation/index.js");
-const { sleep, getSafePort } = require("./browser_test_utilities.js");
+const { sleep } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 
 (async () => {
-    const port = getSafePort();
+    const port = process.env.CURRENT_SAFE_PORT;
     console.log("starting remote listener test");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } }, false);
     await server.expect("ready", 2000);

--- a/javascript/integration-tests/remote-listener-test.js
+++ b/javascript/integration-tests/remote-listener-test.js
@@ -5,7 +5,7 @@ const { sleep } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 
 (async () => {
-    const port = process.env.CURRENT_SAFE_PORT;
+    const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     console.log("starting remote listener test");
     const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } }, false);
     await server.expect("ready", 2000);

--- a/javascript/integration-tests/remote-listener-test.js
+++ b/javascript/integration-tests/remote-listener-test.js
@@ -1,18 +1,19 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector.js");
 const { Database, ensure } = require("../tsc.out/implementation/index.js");
-const { sleep } = require("./browser_test_utilities.js");
+const { sleep, getSafePort } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 
 (async () => {
+    const port = getSafePort();
     console.log("starting remote listener test");
-    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: "9090", ...process.env } }, false);
+    const server = new Expector("./tsc.out/implementation/main.js", [], { env: { GINK_PORT: port, ...process.env } }, false);
     await server.expect("ready", 2000);
 
     const client1 = new Database();
-    await client1.connectTo("ws://localhost:9090");
+    await client1.connectTo(`ws://localhost:${port}`);
     const client2 = new Database();
-    await client2.connectTo("ws://localhost:9090");
+    await client2.connectTo(`ws://localhost:${port}`);
 
     await sleep(200);
     console.log("connections established");

--- a/javascript/integration-tests/routing-server-test.js
+++ b/javascript/integration-tests/routing-server-test.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector");
 const { Database, IndexedDbStore } = require("../tsc.out/implementation");
-const { getSafePort } = require("./browser_test_utilities");
 process.chdir(__dirname + "/..");
 (async function () {
-    const port = getSafePort();
+    const port = process.env.CURRENT_SAFE_PORT;
     new Expector("mkdir", ["-p", "/tmp/routing-server-test"]);
     await new Promise((resolve) => setTimeout(resolve, 10));
     let server;

--- a/javascript/integration-tests/routing-server-test.js
+++ b/javascript/integration-tests/routing-server-test.js
@@ -3,7 +3,7 @@ const Expector = require("./Expector");
 const { Database, IndexedDbStore } = require("../tsc.out/implementation");
 process.chdir(__dirname + "/..");
 (async function () {
-    const port = process.env.CURRENT_SAFE_PORT;
+    const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     new Expector("mkdir", ["-p", "/tmp/routing-server-test"]);
     await new Promise((resolve) => setTimeout(resolve, 10));
     let server;

--- a/javascript/integration-tests/run_integration_tests.sh
+++ b/javascript/integration-tests/run_integration_tests.sh
@@ -1,7 +1,9 @@
 set -o errexit
+export CURRENT_SAFE_PORT=8080
 cd $(dirname $0)
 for file in ./*-test.js;
 do
     echo $file
     ./$file;
+    export CURRENT_SAFE_PORT=$(($CURRENT_SAFE_PORT+1))
 done

--- a/javascript/integration-tests/ts-py-test.js
+++ b/javascript/integration-tests/ts-py-test.js
@@ -3,7 +3,7 @@ const Expector = require("./Expector.js");
 const { sleep } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 (async () => {
-    const port = process.env.CURRENT_SAFE_PORT;
+    const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     console.log("starting");
     const python = new Expector(
         "python3",

--- a/javascript/integration-tests/ts-py-test.js
+++ b/javascript/integration-tests/ts-py-test.js
@@ -1,16 +1,17 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector.js");
-const { sleep } = require("./browser_test_utilities.js");
+const { sleep, getSafePort } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 (async () => {
+    const port = getSafePort();
     console.log("starting");
     const python = new Expector(
         "python3",
-        ["-u", "-m", "gink", "-l", "*:8089"]);
+        ["-u", "-m", "gink", "-l", `*:${port}`]);
     await python.expect("listen", 2000);
     await sleep(500);
 
-    const client = new Expector("node", ["./tsc.out/implementation/main.js", "ws://0.0.0.0:8089"],
+    const client = new Expector("node", ["./tsc.out/implementation/main.js", `ws://0.0.0.0:${port}`],
         { env: { ...process.env } });
     await python.expect("connection established!", 2000);
     await client.expect("connected!", 2000);

--- a/javascript/integration-tests/ts-py-test.js
+++ b/javascript/integration-tests/ts-py-test.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector.js");
-const { sleep, getSafePort } = require("./browser_test_utilities.js");
+const { sleep } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 (async () => {
-    const port = getSafePort();
+    const port = process.env.CURRENT_SAFE_PORT;
     console.log("starting");
     const python = new Expector(
         "python3",

--- a/javascript/integration-tests/wsgi-test.js
+++ b/javascript/integration-tests/wsgi-test.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector.js");
-const { sleep, getSafePort } = require("./browser_test_utilities.js");
+const { sleep } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 (async () => {
-    const port = getSafePort();
+    const port = process.env.CURRENT_SAFE_PORT;
     console.log("starting");
     const server = new Expector(
         "python3",
-        ["-u", "-m", "gink", "--wsgi", "examples.wsgi.hello", `--wsgi_listen_on", "*:${port}`]
+        ["-u", "-m", "gink", "--wsgi", "examples.wsgi.hello", "--wsgi_listen_on", `*:${port}`]
     );
     await server.expect("listening", 2000);
     await sleep(500);

--- a/javascript/integration-tests/wsgi-test.js
+++ b/javascript/integration-tests/wsgi-test.js
@@ -1,17 +1,18 @@
 #!/usr/bin/env -S node --unhandled-rejections=strict
 const Expector = require("./Expector.js");
-const { sleep } = require("./browser_test_utilities.js");
+const { sleep, getSafePort } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 (async () => {
+    const port = getSafePort();
     console.log("starting");
     const server = new Expector(
         "python3",
-        ["-u", "-m", "gink", "--wsgi", "examples.wsgi.hello", "--wsgi_listen_on", "*:8091"]
+        ["-u", "-m", "gink", "--wsgi", "examples.wsgi.hello", `--wsgi_listen_on", "*:${port}`]
     );
     await server.expect("listening", 2000);
     await sleep(500);
 
-    const result = (await (await fetch("http://0.0.0.0:8091")).text()).trim();
+    const result = (await (await fetch(`http://0.0.0.0:${port}`)).text()).trim();
     if (!(result == "Hello, World!")) {
         console.error("FAILED");
         process.exit(1);

--- a/javascript/integration-tests/wsgi-test.js
+++ b/javascript/integration-tests/wsgi-test.js
@@ -3,7 +3,7 @@ const Expector = require("./Expector.js");
 const { sleep } = require("./browser_test_utilities.js");
 process.chdir(__dirname + "/..");
 (async () => {
-    const port = process.env.CURRENT_SAFE_PORT;
+    const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     console.log("starting");
     const server = new Expector(
         "python3",


### PR DESCRIPTION
I am hoping this also fixed a problem of the browser integration tests hanging on mac.

Also I don't really love how I did this, but I couldn't figure out a better way. If two tests are in the same file they will both use the same port number unless it is a constant in the file. Probably ok for now, definitely better than before.