### PR TITLE
get account root from box rather than using global root

### DIFF
--- a/python/gink/impl/braid_server.py
+++ b/python/gink/impl/braid_server.py
@@ -65,7 +65,7 @@ class BraidServer(Server):
             if create_if_missing and key not in current:
                 self._logger.debug("creating intermediate directory for %s", key)
                 current[key] = Directory(database=self._control_db)
-            current = current[key]
+            current = current.get(key)
             if not isinstance(current, Directory):
                 raise ValueError(f"could not traverse: {key}")
         if create_if_missing and braid_key not in current:

--- a/python/gink/impl/braid_server.py
+++ b/python/gink/impl/braid_server.py
@@ -12,6 +12,7 @@ from .server import Server
 from .looping import Selectable
 from .braid import Braid
 from .directory import Directory
+from .box import Box
 from .looping import Finished
 from .bundle_wrapper import BundleWrapper
 from .chain_tracker import ChainTracker
@@ -52,7 +53,14 @@ class BraidServer(Server):
         directory_keys = list(parts[:-1])
         directory_keys.insert(0, 'braids')
         braid_key = parts[-1]
-        current = Directory(arche=True, database=self._control_db)
+        box = Box(arche=True, database=self._control_db)
+        if box.is_empty():
+            if create_if_missing:
+                box.set(Directory(database=self._control_db))
+            else:
+                raise ValueError("app directory not configured!")
+        current = box.get()
+        assert isinstance(current, Directory)
         for key in directory_keys:
             if create_if_missing and key not in current:
                 self._logger.debug("creating intermediate directory for %s", key)

--- a/python/gink/tests/test_braid_server.py
+++ b/python/gink/tests/test_braid_server.py
@@ -16,7 +16,8 @@ def test_happy_path():
     external2 = Database()
     external2.connect_to(target="localhost:9999/abc/xyz", name="external2")
     loop(braid_server, external1, external2, until=0.1)
-    control_root = Directory(arche=True, database=control_db)
+    control_root = Box(arche=True, database=control_db).get()
+    assert isinstance(control_root, Directory)
     braid = control_root["braids"]["abc"]["xyz"]
     assert isinstance(braid, Braid)
     assert list(external1.get_connections())


### PR DESCRIPTION
At some point we're going to need to support hosting multiple applications/accounts from the braid server.  The account ID might get passed in via the domain (e.g. wss://my-app.x5e.io/document).  In any case if someone starts hosting on their own then decides that they want to start using X5E hosting, we have to effectively merge their braid server control database with ours, so we can't use the global root as the basis for everything.