### PR TITLE
send bundle view instead of info to listeners

### DIFF
--- a/javascript/implementation/CommandLineInterface.ts
+++ b/javascript/implementation/CommandLineInterface.ts
@@ -2,7 +2,7 @@ import { RoutingServer } from "./RoutingServer";
 import { LogBackedStore } from "./LogBackedStore";
 import { Store } from "./Store";
 import { Database } from "./Database";
-import { AuthFunction, BundleInfo } from "./typedefs";
+import { AuthFunction, BundleInfo, BundleView } from "./typedefs";
 import { SimpleServer } from "./SimpleServer";
 import { ensure, generateTimestamp, getIdentity, logToStdErr } from "./utils";
 import { IndexedDbStore } from "./IndexedDbStore";
@@ -100,7 +100,7 @@ export class CommandLineInterface {
             globalThis.database = this.instance;
             globalThis.root = this.instance.getGlobalDirectory();
             this.instance.addListener(
-                async (bundleInfo: BundleInfo) => logToStdErr(`received bundle: ${JSON.stringify(bundleInfo)}`));
+                async (bundle: BundleView) => logToStdErr(`received bundle: ${JSON.stringify(bundle.info)}`));
             for (const target of this.targets) {
                 logToStdErr(`connecting to: ${target}`);
                 try {

--- a/javascript/implementation/Database.ts
+++ b/javascript/implementation/Database.ts
@@ -66,7 +66,7 @@ export class Database {
             }
             // Send to listeners subscribed to all containers.
             for (const listener of this.getListeners()) {
-                listener(bundle.info);
+                listener(bundle);
             }
         };
         this.store.addFoundBundleCallBack(callback);
@@ -351,7 +351,7 @@ export class Database {
             }
             // Send to listeners subscribed to all containers.
             for (const listener of this.getListeners()) {
-                listener(bundle.info);
+                listener(bundle);
             }
 
             if (this.listeners.size > 1) {
@@ -385,11 +385,11 @@ export class Database {
                     const containerListeners = this.getListeners(false, muid);
                     const remoteOnlyListeners = this.getListeners(true, muid);
                     for (const listener of containerListeners) {
-                        listener(bundle.info);
+                        listener(bundle);
                     }
                     if (fromConnectionId) {
                         for (const remoteListener of remoteOnlyListeners) {
-                            remoteListener(bundle.info);
+                            remoteListener(bundle);
                         }
                     }
                 }

--- a/javascript/implementation/typedefs.ts
+++ b/javascript/implementation/typedefs.ts
@@ -24,7 +24,7 @@ export type ActorId = number;  // process ID on the server side, something more 
 export type StorageKey = ScalarKey | MuidTuple | [MuidTuple, MuidTuple] | [];
 
 export interface BundleListener {
-    (bundleInfo: BundleInfo): Promise<void>;
+    (bundle: BundleView): Promise<void>;
 }
 
 export interface ClaimedChain {

--- a/javascript/integration-tests/browser-tests/client-side-script.js
+++ b/javascript/integration-tests/browser-tests/client-side-script.js
@@ -13,11 +13,12 @@ function getWebsocketTarget() {
     return target;
 }
 
-async function onBundle(changeSetInfo) {
+async function onBundle(changeSet) {
     if (document == null) { throw new Error("unexpected"); }
     document.getElementById('messages').innerHTML +=
-        `${changeSetInfo.medallion}, ${changeSetInfo.timestamp}, ` +
-        `"${changeSetInfo.comment}"\n`;
+        `${changeSet.info.medallion}, ${changeSet.info.timestamp}, ` +
+        `"${changeSet.info.comment}"\n`;
+
 }
 
 (async () => {

--- a/javascript/unit-tests/LogBackedStore.test.ts
+++ b/javascript/unit-tests/LogBackedStore.test.ts
@@ -1,6 +1,6 @@
 import { Database, LogBackedStore, ensure } from "../implementation/main";
 import { testStore } from "./Store.test";
-import { truncateSync, existsSync, unlinkSync, readFileSync } from "fs";
+import { existsSync, unlinkSync, readFileSync } from "fs";
 
 function createMaker(reset: boolean, testFile = "/tmp/test.store") {
     return async function () {


### PR DESCRIPTION
If people are going to be listening for changes, it would make sense for them to easily be able to see what changes were made in a received bundle. That is still a little buried in the builder, but WAY more accessible like this.