### PR TITLE
refactoring container/subclass constructors and fixing container dumps

### DIFF
--- a/python/gink/__main__.py
+++ b/python/gink/__main__.py
@@ -144,7 +144,7 @@ if args.mkdir:
         if not component: continue
         old_directory = old_directory.get(component, as_of=args.as_of)
         assert isinstance(old_directory, Directory)
-    new_directory = Directory.create(database=database)
+    new_directory = Directory(database=database)
     old_directory.set(path_components[-1], new_directory, comment=args.comment)
     database.close()
     exit(0)

--- a/python/gink/impl/addressable.py
+++ b/python/gink/impl/addressable.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
-from typing import Optional
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 from .database import Database
 from .muid import Muid
@@ -12,7 +11,7 @@ from typing import Dict
 
 class Addressable:
     def __init__(self, database: Database, muid: Muid):
-        self._database: Database = database
+        self._database: Database = database or Database.get_last()
         self._muid: Muid = muid
 
     def get_muid(self):

--- a/python/gink/impl/box.py
+++ b/python/gink/impl/box.py
@@ -74,7 +74,7 @@ class Box(Container):
         if self._muid.medallion == -1 and self._muid.timestamp == -1:
             identifier = "arche=True"
         else:
-            identifier = repr(str(self._muid))
+            identifier = f"muid={self._muid!r}"
 
         as_of = self._database.resolve_timestamp(as_of)
         found = self._database.get_store().get_entry_by_key(container=self._muid, key=None, as_of=as_of)

--- a/python/gink/impl/box.py
+++ b/python/gink/impl/box.py
@@ -13,18 +13,24 @@ class Box(Container):
     BEHAVIOR = BOX
 
     def __init__(
-                self,
-                muid: Optional[Union[Muid, str]] = None,
-                *,
-                arche: Optional[bool] = None,
-                contents = None,
-                database: Optional[Database]=None,
-                bundler: Optional[Bundler] = None,
-                comment: Optional[str] = None,
-            ):
+            self,
+            muid: Optional[Union[Muid, str]] = None,
+            *,
+            arche: Optional[bool] = None,
+            contents = None,
+            database: Optional[Database] = None,
+            bundler: Optional[Bundler] = None,
+            comment: Optional[str] = None,
+    ):
         """
-        muid: the global id of this sequence, created on the fly if None
-        database: where to send bundles through, or last db instance created if None
+        Constructor for a box proxy.
+
+        muid: the global id of this container, created on the fly if None
+        arche: whether this will be the global version of this container (accessible by all databases)
+        contents: prefill the box with a value upon initialization
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
         """
         immediate = False
         if bundler is None:
@@ -38,7 +44,7 @@ class Box(Container):
                 arche=arche,
                 database=database,
                 bundler=bundler,
-            )
+        )
 
         if contents is not None:
             self.clear(bundler=bundler)

--- a/python/gink/impl/box.py
+++ b/python/gink/impl/box.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 #gink implementation
 from .typedefs import GenericTimestamp
@@ -12,37 +12,38 @@ from .coding import BOX
 class Box(Container):
     BEHAVIOR = BOX
 
-    def __init__(self, *ordered,
-                 arche: Optional[bool] = None,
-                 bundler: Optional[Bundler] = None,
-                 contents = None,
-                 muid: Optional[Muid] = None,
-                 database: Optional[Database]=None,
-                 comment: Optional[str] = None,
-                 ):
+    def __init__(
+                self,
+                muid: Optional[Union[Muid, str]] = None,
+                *,
+                arche: Optional[bool] = None,
+                contents = None,
+                database: Optional[Database]=None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
         """
         muid: the global id of this sequence, created on the fly if None
         database: where to send bundles through, or last db instance created if None
         """
-        if ordered:
-            if isinstance(ordered[0], str):
-                muid = Muid.from_str(ordered[0])
-        if arche:
-            muid = Muid(-1, -1, BOX)
-        database = database or Database.get_last()
         immediate = False
         if bundler is None:
             immediate = True
             bundler = Bundler(comment)
-        if muid is None:
-            muid = Container._create(BOX, database=database, bundler=bundler)
 
-        Container.__init__(self, muid=muid, database=database)
-        self._muid = muid
-        self._database = database
+        Container.__init__(
+                self,
+                behavior=BOX,
+                muid=muid,
+                arche=arche,
+                database=database,
+                bundler=bundler,
+            )
+
         if contents is not None:
             self.clear(bundler=bundler)
             self.set(contents, bundler=bundler)
+
         if immediate and len(bundler):
             self._database.bundle(bundler)
 

--- a/python/gink/impl/braid.py
+++ b/python/gink/impl/braid.py
@@ -14,20 +14,34 @@ from .bundler import Bundler
 class Braid(Container):
     BEHAVIOR = BRAID
 
-    def __init__(self, muid: Optional[Muid] = None, *, arche: bool=False, database: Optional[Database]=None,
-                 contents: Optional[Dict[Chain, Limit]]=None):
-        database = database or Database.get_last()
-        bundler = Bundler()
-        if arche:
-            muid = Muid(-1, -1, self.__class__.BEHAVIOR)
-        if muid is None:
-            muid = Container._create(self.__class__.BEHAVIOR, database=database, bundler=bundler)
-        Container.__init__(self, muid=muid, database=database)
+    def __init__(
+                self,
+                muid: Optional[Union[Muid, str]] = None,
+                *,
+                arche: Optional[bool] = None,
+                contents: Optional[Dict[Chain, Limit]] = None,
+                database: Optional[Database] = None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
+        immediate = False
+        if bundler is None:
+            immediate = True
+            bundler = Bundler(comment)
+
+        Container.__init__(
+                self,
+                behavior=BRAID,
+                muid=muid,
+                arche=arche,
+                database=database,
+                bundler=bundler,
+            )
         if contents:
             self.clear(bundler=bundler)
             self.update(contents, bundler=bundler)
 
-        if len(bundler):
+        if immediate and len(bundler):
             self._database.bundle(bundler)
 
     def dumps(self, as_of: GenericTimestamp = None) -> str:

--- a/python/gink/impl/braid.py
+++ b/python/gink/impl/braid.py
@@ -15,15 +15,25 @@ class Braid(Container):
     BEHAVIOR = BRAID
 
     def __init__(
-                self,
-                muid: Optional[Union[Muid, str]] = None,
-                *,
-                arche: Optional[bool] = None,
-                contents: Optional[Dict[Chain, Limit]] = None,
-                database: Optional[Database] = None,
-                bundler: Optional[Bundler] = None,
-                comment: Optional[str] = None,
-            ):
+            self,
+            muid: Optional[Union[Muid, str]] = None,
+            *,
+            arche: Optional[bool] = None,
+            contents: Optional[Dict[Chain, Limit]] = None,
+            database: Optional[Database] = None,
+            bundler: Optional[Bundler] = None,
+            comment: Optional[str] = None,
+    ):
+        """
+        Constructor for a braid proxy.
+
+        muid: the global id of this container, created on the fly if None
+        arche: whether this will be the global version of this container (accessible by all databases)
+        contents: prefill the braid with a dict of Chain: Limit upon initialization
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
+        """
         immediate = False
         if bundler is None:
             immediate = True
@@ -36,7 +46,7 @@ class Braid(Container):
                 arche=arche,
                 database=database,
                 bundler=bundler,
-            )
+        )
         if contents:
             self.clear(bundler=bundler)
             self.update(contents, bundler=bundler)

--- a/python/gink/impl/container.py
+++ b/python/gink/impl/container.py
@@ -17,6 +17,26 @@ from .utilities import generate_timestamp
 
 class Container(Addressable, ABC):
     """ Abstract base class for mutable data types (directories, sequences, etc). """
+    def __init__(self,
+                 behavior: int,
+                 *,
+                 bundler: Bundler,
+                 muid: Optional[Union[Muid, str]] = None,
+                 arche: Optional[bool] = None,
+                 database: Optional[Database]=None,
+                 ):
+        assert isinstance(bundler, Bundler), "must pass a bundler to Container.__init__"
+        if isinstance(muid, str):
+            muid = Muid.from_str(muid)
+        if arche:
+            muid = Muid(-1, -1, behavior)
+        database = database or Database.get_last()
+        if muid is None:
+            muid = Container._create(behavior, database=database, bundler=bundler)
+
+        # self._muid and self._database are set by Addressable.__init__
+        Addressable.__init__(self, database=database, muid=muid)
+
 
     def __repr__(self):
         if self._muid.timestamp == -1 and self._muid.medallion == -1:

--- a/python/gink/impl/directory.py
+++ b/python/gink/impl/directory.py
@@ -22,20 +22,24 @@ class Directory(Container):
     BEHAVIOR = DIRECTORY
 
     def __init__(
-                self,
-                muid: Optional[Union[Muid, str]] = None,
-                *,
-                arche: Optional[bool] = None,
-                contents: Optional[dict]=None,
-                database: Optional[Database]=None,
-                bundler: Optional[Bundler] = None,
-                comment: Optional[str] = None,
-            ):
+            self,
+            muid: Optional[Union[Muid, str]] = None,
+            *,
+            arche: Optional[bool] = None,
+            contents: Optional[dict] = None,
+            database: Optional[Database] = None,
+            bundler: Optional[Bundler] = None,
+            comment: Optional[str] = None,
+    ):
         """
         Constructor for a directory proxy.
 
-        muid: the global id of this directory, created on the fly if None
-        db: database send bundles through, or last db instance created if None
+        muid: the global id of this container, created on the fly if None
+        arche: whether this will be the global version of this container (accessible by all databases)
+        contents: prefill the directory with a dict of key: value pairs upon initialization
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
         """
         self._logger = getLogger(self.__class__.__name__)
 
@@ -54,7 +58,7 @@ class Directory(Container):
                 arche=arche,
                 database=database,
                 bundler=bundler,
-            )
+        )
 
         if contents:
             self.clear(bundler=bundler)

--- a/python/gink/impl/directory.py
+++ b/python/gink/impl/directory.py
@@ -69,7 +69,7 @@ class Directory(Container):
         if self._muid.medallion == -1 and self._muid.timestamp == -1:
             identifier = "arche=True"
         else:
-            identifier = repr(str(self._muid))
+            identifier = f"muid={self._muid!r}"
         result = f"""{self.__class__.__name__}({identifier}, contents="""
         result += "{"
         stuffing = [f"{key!r}: {val!r}" for key, val in self.items(as_of=as_of)]

--- a/python/gink/impl/directory.py
+++ b/python/gink/impl/directory.py
@@ -21,14 +21,16 @@ class Directory(Container):
     _missing = object()
     BEHAVIOR = DIRECTORY
 
-    def __init__(self, *ordered,
-                 arche: Optional[bool] = None,
-                 bundler: Optional[Bundler] = None,
-                 contents: Optional[dict]=None,
-                 muid: Optional[Muid] = None,
-                 database: Optional[Database]=None,
-                 comment: Optional[str] = None,
-                 ):
+    def __init__(
+                self,
+                muid: Optional[Union[Muid, str]] = None,
+                *,
+                arche: Optional[bool] = None,
+                contents: Optional[dict]=None,
+                database: Optional[Database]=None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
         """
         Constructor for a directory proxy.
 
@@ -37,25 +39,27 @@ class Directory(Container):
         """
         self._logger = getLogger(self.__class__.__name__)
 
-        if ordered:
-            if isinstance(ordered[0], str):
-                muid = Muid.from_str(ordered[0])
-        if arche:
-            muid = Muid(-1, -1, DIRECTORY)
-        database = database or Database.get_last()
+        # if muid and muid.timestamp > 0 and contents:
+        # TODO [P3] check the store to make sure that the container is defined and compatible
+
         immediate = False
         if bundler is None:
             immediate = True
             bundler = Bundler(comment)
-        if muid is None:
-            muid = Container._create(DIRECTORY, database=database, bundler=bundler)
-        elif muid.timestamp > 0 and contents:
-            # TODO [P3] check the store to make sure that the container is defined and compatible
-            pass
-        Container.__init__(self, muid=muid, database=database)
+
+        Container.__init__(
+                self,
+                behavior=DIRECTORY,
+                muid=muid,
+                arche=arche,
+                database=database,
+                bundler=bundler,
+            )
+
         if contents:
             self.clear(bundler=bundler)
             self.update(contents, bundler=bundler)
+
         if immediate and len(bundler):
             self._database.bundle(bundler)
 

--- a/python/gink/impl/graph.py
+++ b/python/gink/impl/graph.py
@@ -17,11 +17,15 @@ from .utilities import experimental
 class Vertex(Container):
     BEHAVIOR = VERTEX
 
-    def __init__(self, *,
-                 arche: bool = False,
-                 muid: Optional[Muid] = None,
-                 bundler: Optional[Bundler] = None,
-                 database: Optional[Database] = None):
+    def __init__(
+                self,
+                muid: Optional[Union[Muid, str]] = None,
+                *,
+                arche: Optional[bool] = None,
+                database: Optional[Database]=None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
         """
         Creates a placeholder node to contain the idea of something.
 
@@ -32,12 +36,16 @@ class Vertex(Container):
         immediate = False
         if not isinstance(bundler, Bundler):
             immediate = True
-            bundler = Bundler()
-        if arche:
-            muid = Muid(-1, -1, VERTEX)
-        if muid is None:
-            muid = Container._create(VERTEX, database=database, bundler=bundler)
-        Container.__init__(self, muid=muid, database=database)
+            bundler = Bundler(comment)
+
+        Container.__init__(self,
+                behavior=VERTEX,
+                muid=muid,
+                arche=arche,
+                database=database,
+                bundler=bundler,
+            )
+
         if len(bundler) and immediate:
             self._database.bundle(bundler)
 
@@ -97,21 +105,34 @@ Database.register_container_type(Vertex)
 class Verb(Container):
     BEHAVIOR = EDGE_TYPE
 
-    def __init__(self, *,
-                 arche=False,
-                 muid: Optional[Muid] = None,
-                 database: Optional[Database] = None,
-                 contents: Optional[Iterable[Edge]] = None):
-        database = database or Database.get_last()
-        bundler = Bundler()
-        if arche:
-            muid = Muid(-1, -1, EDGE_TYPE)
-        if muid is None:
-            muid = Container._create(EDGE_TYPE, database=database, bundler=bundler)
-        Container.__init__(self, muid=muid, database=database)
+    def __init__(
+                self,
+                *,
+                muid: Optional[Union[Muid, str]] = None,
+                arche: Optional[bool] = None,
+                contents: Optional[Iterable[Edge]] = None,
+                database: Optional[Database]=None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
+        immediate = False
+        if bundler is None:
+            immediate = True
+            bundler = Bundler(comment)
+
+        Container.__init__(
+                self,
+                behavior=EDGE_TYPE,
+                muid=muid,
+                arche=arche,
+                database=database,
+                bundler=bundler,
+            )
+
         if contents:
             pass  # This is intentional! The edge constructors will restore them!
-        if len(bundler):
+
+        if immediate and len(bundler):
             self._database.bundle(bundler)
 
     def create_edge(

--- a/python/gink/impl/graph.py
+++ b/python/gink/impl/graph.py
@@ -18,19 +18,22 @@ class Vertex(Container):
     BEHAVIOR = VERTEX
 
     def __init__(
-                self,
-                muid: Optional[Union[Muid, str]] = None,
-                *,
-                arche: Optional[bool] = None,
-                database: Optional[Database]=None,
-                bundler: Optional[Bundler] = None,
-                comment: Optional[str] = None,
-            ):
+            self,
+            muid: Optional[Union[Muid, str]] = None,
+            *,
+            arche: Optional[bool] = None,
+            database: Optional[Database] = None,
+            bundler: Optional[Bundler] = None,
+            comment: Optional[str] = None,
+    ):
         """
         Creates a placeholder node to contain the idea of something.
 
-        muid: the global id of this vertex, created on the fly if None
-        db: database send bundles through, or last db instance created if None
+        muid: the global id of this container, created on the fly if None
+        arche: whether this will be the global version of this container (accessible by all databases)
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
         """
         database = database or Database.get_last()
         immediate = False
@@ -38,13 +41,14 @@ class Vertex(Container):
             immediate = True
             bundler = Bundler(comment)
 
-        Container.__init__(self,
+        Container.__init__(
+                self,
                 behavior=VERTEX,
                 muid=muid,
                 arche=arche,
                 database=database,
                 bundler=bundler,
-            )
+        )
 
         if len(bundler) and immediate:
             self._database.bundle(bundler)
@@ -106,15 +110,25 @@ class Verb(Container):
     BEHAVIOR = EDGE_TYPE
 
     def __init__(
-                self,
-                *,
-                muid: Optional[Union[Muid, str]] = None,
-                arche: Optional[bool] = None,
-                contents: Optional[Iterable[Edge]] = None,
-                database: Optional[Database]=None,
-                bundler: Optional[Bundler] = None,
-                comment: Optional[str] = None,
-            ):
+            self,
+            *,
+            muid: Optional[Union[Muid, str]] = None,
+            arche: Optional[bool] = None,
+            contents: Optional[Iterable[Edge]] = None,
+            database: Optional[Database] = None,
+            bundler: Optional[Bundler] = None,
+            comment: Optional[str] = None,
+    ):
+        """
+        Constructor for a Verb (otherwise known as Edge Type).
+
+        muid: the global id of this container, created on the fly if None
+        arche: whether this will be the global version of this container (accessible by all databases)
+        contents: prefill the Verb with an iterable of edges upon initialization
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
+        """
         immediate = False
         if bundler is None:
             immediate = True
@@ -127,7 +141,7 @@ class Verb(Container):
                 arche=arche,
                 database=database,
                 bundler=bundler,
-            )
+        )
 
         if contents:
             pass  # This is intentional! The edge constructors will restore them!

--- a/python/gink/impl/group.py
+++ b/python/gink/impl/group.py
@@ -63,7 +63,7 @@ class Group(Container):
     def dumps(self, as_of: GenericTimestamp = None) -> str:
         """ Dumps the contents of this group to a string.
         """
-        identifier = repr(str(self._muid))
+        identifier = f"muid={self._muid!r}"
         result = f"""{self.__class__.__name__}({identifier}, contents="""
         result += "{"
         stuffing = [repr(_) for _ in self.get_member_ids(as_of=as_of)]

--- a/python/gink/impl/group.py
+++ b/python/gink/impl/group.py
@@ -19,15 +19,18 @@ class Group(Container):
                 muid: Optional[Union[Muid, str]] = None,
                 *,
                 contents: Optional[Set[Union[Muid, Container]]] = None,
-                database: Optional[Database]=None,
+                database: Optional[Database] = None,
                 bundler: Optional[Bundler] = None,
                 comment: Optional[str] = None,
             ):
         """
         Constructor for a group definition.
 
-        muid: the global id of this directory, created on the fly if None
-        db: database send bundles through, or last db instance created if None
+        muid: the global id of this container, created on the fly if None
+        contents: prefill the group with a set of muids or containers upon initialization
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
         """
         immediate = False
         if bundler is None:

--- a/python/gink/impl/group.py
+++ b/python/gink/impl/group.py
@@ -4,7 +4,7 @@ from typing import Optional, Union, Set, Iterable
 
 from .typedefs import GenericTimestamp
 from .container import Container
-from .coding import deletion, inclusion
+from .coding import deletion, inclusion, GROUP
 from .muid import Muid
 from .database import Database
 from .bundler import Bundler
@@ -14,22 +14,38 @@ from .builders import Behavior
 class Group(Container):
     BEHAVIOR = Behavior.GROUP
 
-    def __init__(self, *, contents: Optional[Set[Union[Muid, Container]]] = None,
-                 muid: Optional[Muid] = None, database=None):
+    def __init__(
+                self,
+                muid: Optional[Union[Muid, str]] = None,
+                *,
+                contents: Optional[Set[Union[Muid, Container]]] = None,
+                database: Optional[Database]=None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
         """
         Constructor for a group definition.
 
         muid: the global id of this directory, created on the fly if None
         db: database send bundles through, or last db instance created if None
         """
-        database = database or Database.get_last()
-        bundler = Bundler()
-        if muid is None:
-            muid = Container._create(Behavior.GROUP, database=database, bundler=bundler)
-        Container.__init__(self, muid=muid, database=database)
+        immediate = False
+        if bundler is None:
+            immediate = True
+            bundler = Bundler(comment)
+
+        Container.__init__(
+                self,
+                behavior=GROUP,
+                muid=muid,
+                arche=False,
+                database=database,
+                bundler=bundler,
+            )
+
         if contents:
             raise NotImplementedError()
-        if len(bundler):
+        if immediate and len(bundler):
             self._database.bundle(bundler)
 
     def include(self, what: Union[Muid, Container], *,

--- a/python/gink/impl/key_set.py
+++ b/python/gink/impl/key_set.py
@@ -16,19 +16,22 @@ class KeySet(Container):
     BEHAVIOR = KEY_SET
 
     def __init__(
-                self,
-                muid: Optional[Union[Muid, str]] = None,
-                *,
-                contents = None,
-                database: Optional[Database]=None,
-                bundler: Optional[Bundler] = None,
-                comment: Optional[str] = None,
-            ):
+            self,
+            muid: Optional[Union[Muid, str]] = None,
+            *,
+            contents: Optional[Iterable[UserKey]] = None,
+            database: Optional[Database] = None,
+            bundler: Optional[Bundler] = None,
+            comment: Optional[str] = None,
+    ):
         """
         Constructor for a set proxy.
 
-        muid: the global id of this set, created on the fly if None
-        db: database to send bundles through, or last db instance created if None
+        muid: the global id of this container, created on the fly if None
+        contents: prefill the key set with an iterable of keys upon initialization
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
         """
         # if muid and muid.timestamp > 0 and contents:
         # TODO [P3] check the store to make sure that the container is defined and compatible (possibly for set as well?)
@@ -45,7 +48,7 @@ class KeySet(Container):
                 arche=False,
                 database=database,
                 bundler=bundler,
-            )
+        )
 
         if contents:
             self.clear(bundler=bundler)

--- a/python/gink/impl/key_set.py
+++ b/python/gink/impl/key_set.py
@@ -1,6 +1,6 @@
 """ Contains the key set class definition """
 
-from typing import Optional, Iterable, Container as StandardContainer, Set
+from typing import Optional, Iterable, Container as StandardContainer, Set, Union
 
 from .database import Database
 from .muid import Muid
@@ -15,27 +15,38 @@ class KeySet(Container):
     _missing = object()
     BEHAVIOR = KEY_SET
 
-    def __init__(self, arche: Optional[bool] = None, bundler: Optional[Bundler] = None, contents = None,
-                 muid: Optional[Muid] = None, database = None, comment: Optional[str] = None):
+    def __init__(
+                self,
+                muid: Optional[Union[Muid, str]] = None,
+                *,
+                contents = None,
+                database: Optional[Database]=None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
         """
         Constructor for a set proxy.
 
         muid: the global id of this set, created on the fly if None
         db: database to send bundles through, or last db instance created if None
         """
-        if arche:
-            muid = Muid(-1, -1, KEY_SET)
-        database = database or Database.get_last()
+        # if muid and muid.timestamp > 0 and contents:
+        # TODO [P3] check the store to make sure that the container is defined and compatible (possibly for set as well?)
+
         immediate = False
         if bundler is None:
             immediate = True
             bundler = Bundler(comment)
-        if muid is None:
-            muid = Container._create(KEY_SET, database=database, bundler=bundler)
-        elif muid.timestamp > 0 and contents:
-            # TODO [P3] check the store to make sure that the container is defined and compatible (possibly for set as well?)
-            pass
-        Container.__init__(self, muid=muid, database=database)
+
+        Container.__init__(
+                self,
+                behavior=KEY_SET,
+                muid=muid,
+                arche=False,
+                database=database,
+                bundler=bundler,
+            )
+
         if contents:
             self.clear(bundler=bundler)
             self.update(contents, bundler=bundler)

--- a/python/gink/impl/key_set.py
+++ b/python/gink/impl/key_set.py
@@ -220,11 +220,11 @@ class KeySet(Container):
     def dumps(self, as_of: GenericTimestamp = None) -> str:
         """ return the contents of this container as a string """
         as_of = self._database.resolve_timestamp(as_of)
-        identifier = repr(str(self._muid))
+        identifier = f"muid={self._muid!r}"
         result = f"""{self.__class__.__name__}({identifier}, contents="""
         result += "{"
         src = self._database.get_store().get_keyed_entries(container=self._muid, behavior=self.BEHAVIOR, as_of=as_of)
-        stuffing = [str(decode_key(entry_pair.builder)) for entry_pair in src]
+        stuffing = [repr(decode_key(entry_pair.builder)) for entry_pair in src]
         as_one_line = result + ",".join(stuffing) + "})"
         if len(as_one_line) < 80:
             return as_one_line

--- a/python/gink/impl/pair_map.py
+++ b/python/gink/impl/pair_map.py
@@ -1,6 +1,6 @@
 """ Contains the pair map class definition """
 
-from typing import Optional, Tuple, Union, Iterable
+from typing import Optional, Tuple, Union
 from .database import Database
 from .muid import Muid
 from .container import Container
@@ -13,9 +13,16 @@ class PairMap(Container):
     _missing = object()
     BEHAVIOR = PAIR_MAP
 
-    def __init__(self, arche: Optional[bool] = None, bundler: Optional[Bundler] = None,
-                 contents: Optional[dict] = None, muid: Optional[Muid] = None,
-                 database = None, comment: Optional[str] = None):
+    def __init__(
+                self,
+                muid: Optional[Union[Muid, str]] = None,
+                *,
+                arche: Optional[bool] = None,
+                contents: Optional[dict]=None,
+                database: Optional[Database]=None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
         """
         Constructor for a pair set proxy.
 
@@ -23,19 +30,22 @@ class PairMap(Container):
         muid: the global id of this pair set, created on the fly if None
         db: database to send bundles through, or last db instance created if None
         """
-        if arche:
-            muid = Muid(-1, -1, PAIR_MAP)
-        database = database or Database.get_last()
+        # if muid and muid.timestamp > 0 and contents:
+        # TODO [P3] check the store to make sure that the container is defined and compatible
+
         immediate = False
         if bundler is None:
             immediate = True
             bundler = Bundler(comment)
-        if muid is None:
-            muid = Container._create(PAIR_MAP, database=database, bundler=bundler)
-        elif muid.timestamp > 0 and contents:
-            # TODO [P3] check the store to make sure that the container is defined and compatible
-            pass
-        Container.__init__(self, muid=muid, database=database)
+
+        Container.__init__(
+                self,
+                behavior=PAIR_MAP,
+                muid=muid,
+                arche=arche,
+                database=database,
+                bundler=bundler,
+            )
         if contents:
             self.clear(bundler=bundler)
             for key_pair, value in contents.items():

--- a/python/gink/impl/pair_map.py
+++ b/python/gink/impl/pair_map.py
@@ -123,7 +123,7 @@ class PairMap(Container):
         if self._muid.medallion == -1 and self._muid.timestamp == -1:
             identifier = "arche=True"
         else:
-            identifier = repr(str(self._muid))
+            identifier = f"muid={self._muid!r}"
         result = f"""{self.__class__.__name__}({identifier}, contents="""
         result += "{"
         stuffing = ""
@@ -136,7 +136,7 @@ class PairMap(Container):
                 value = decode_entry_occupant(self._muid, entry_pair.builder)
                 stuffing += f"""\n\t(Muid{(left.timestamp, left.medallion, left.offset)},
                 Muid{(rite.timestamp, rite.medallion, rite.offset)}):
-                "{value if not isinstance(value, bytes) else value!r}","""
+                {value if not isinstance(value, bytes) else value!r},"""
 
         as_one_line = result + ", ".join(stuffing) + "})"
         if len(as_one_line) < 80:

--- a/python/gink/impl/pair_map.py
+++ b/python/gink/impl/pair_map.py
@@ -14,21 +14,24 @@ class PairMap(Container):
     BEHAVIOR = PAIR_MAP
 
     def __init__(
-                self,
-                muid: Optional[Union[Muid, str]] = None,
-                *,
-                arche: Optional[bool] = None,
-                contents: Optional[dict]=None,
-                database: Optional[Database]=None,
-                bundler: Optional[Bundler] = None,
-                comment: Optional[str] = None,
-            ):
+            self,
+            muid: Optional[Union[Muid, str]] = None,
+            *,
+            arche: Optional[bool] = None,
+            contents: Optional[dict] = None,
+            database: Optional[Database] = None,
+            bundler: Optional[Bundler] = None,
+            comment: Optional[str] = None,
+    ):
         """
-        Constructor for a pair set proxy.
+        Constructor for a pair map proxy.
 
-        contents: dictionary of (Vertex, Vertex): Value to populate the pair map
-        muid: the global id of this pair set, created on the fly if None
-        db: database to send bundles through, or last db instance created if None
+        muid: the global id of this container, created on the fly if None
+        arche: whether this will be the global version of this container (accessible by all databases)
+        contents: prefill the pair map with a dict of (Vertex, Vertex): Value pairs upon initialization
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
         """
         # if muid and muid.timestamp > 0 and contents:
         # TODO [P3] check the store to make sure that the container is defined and compatible

--- a/python/gink/impl/pair_set.py
+++ b/python/gink/impl/pair_set.py
@@ -17,7 +17,6 @@ class PairSet(Container):
                 self,
                 muid: Optional[Union[Muid, str]] = None,
                 *,
-                arche: Optional[bool] = None,
                 contents: Union[Iterable[Tuple[Vertex, Vertex]], None] = None,
                 database: Optional[Database]=None,
                 bundler: Optional[Bundler] = None,
@@ -42,7 +41,7 @@ class PairSet(Container):
                 self,
                 behavior=PAIR_SET,
                 muid=muid,
-                arche=arche,
+                arche=False,
                 database=database,
                 bundler=bundler,
             )
@@ -106,7 +105,7 @@ class PairSet(Container):
     def dumps(self, as_of: GenericTimestamp = None) -> str:
         """ return the contents of this container as a string """
         as_of = self._database.resolve_timestamp(as_of)
-        identifier = repr(str(self._muid))
+        identifier = f"muid={self._muid!r}"
         result = f"""{self.__class__.__name__}({identifier}, contents="""
         result += "["
         stuffing = ""

--- a/python/gink/impl/pair_set.py
+++ b/python/gink/impl/pair_set.py
@@ -18,16 +18,19 @@ class PairSet(Container):
                 muid: Optional[Union[Muid, str]] = None,
                 *,
                 contents: Union[Iterable[Tuple[Vertex, Vertex]], None] = None,
-                database: Optional[Database]=None,
+                database: Optional[Database] = None,
                 bundler: Optional[Bundler] = None,
                 comment: Optional[str] = None,
             ):
         """
         Constructor for a pair set proxy.
 
-        muid: the global id of this pair set, created on the fly if None
-        contents: an iterable of pairs (an iterable of tuples) to populate the pair set at initialization
-        db: database to send bundles through, or last db instance created if None
+        muid: the global id of this container, created on the fly if None
+        arche: whether this will be the global version of this container (accessible by all databases)
+        contents: prefill the pair set with an iterable of (Vertex, Vertex) upon initialization
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
         """
         # if muid and muid.timestamp > 0 and contents:
         # TODO [P3] check the store to make sure that the container is defined and compatible

--- a/python/gink/impl/pair_set.py
+++ b/python/gink/impl/pair_set.py
@@ -13,9 +13,16 @@ class PairSet(Container):
     _missing = object()
     BEHAVIOR = PAIR_SET
 
-    def __init__(self, arche: Optional[bool] = None, bundler: Optional[Bundler] = None,
-                 contents: Union[Iterable[Tuple[Vertex, Vertex]], None] = None,
-                 muid: Optional[Muid] = None, database = None, comment: Optional[str] = None):
+    def __init__(
+                self,
+                muid: Optional[Union[Muid, str]] = None,
+                *,
+                arche: Optional[bool] = None,
+                contents: Union[Iterable[Tuple[Vertex, Vertex]], None] = None,
+                database: Optional[Database]=None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
         """
         Constructor for a pair set proxy.
 
@@ -23,19 +30,22 @@ class PairSet(Container):
         contents: an iterable of pairs (an iterable of tuples) to populate the pair set at initialization
         db: database to send bundles through, or last db instance created if None
         """
-        if arche:
-            muid = Muid(-1, -1, PAIR_SET)
-        database = database or Database.get_last()
+        # if muid and muid.timestamp > 0 and contents:
+        # TODO [P3] check the store to make sure that the container is defined and compatible
+
         immediate = False
         if bundler is None:
             immediate = True
             bundler = Bundler(comment)
-        if muid is None:
-            muid = Container._create(PAIR_SET, database=database, bundler=bundler)
-        elif muid.timestamp > 0 and contents:
-            # TODO [P3] check the store to make sure that the container is defined and compatible
-            pass
-        Container.__init__(self, muid=muid, database=database)
+
+        Container.__init__(
+                self,
+                behavior=PAIR_SET,
+                muid=muid,
+                arche=arche,
+                database=database,
+                bundler=bundler,
+            )
         if contents:
             self.clear(bundler=bundler)
             for item in contents:

--- a/python/gink/impl/property.py
+++ b/python/gink/impl/property.py
@@ -55,7 +55,7 @@ class Property(Container):
         if self._muid.medallion == -1 and self._muid.timestamp == -1:
             identifier = "arche=True"
         else:
-            identifier = repr(str(self._muid))
+            identifier = f"muid={self._muid!r}"
         result = f"""{self.__class__.__name__}({identifier}, contents="""
         result += "{"
         stuffing = [f"{k!r}:{v!r}" for k, v in self.items(as_of=as_of)]

--- a/python/gink/impl/property.py
+++ b/python/gink/impl/property.py
@@ -14,39 +14,38 @@ from .graph import Edge
 class Property(Container):
     BEHAVIOR = PROPERTY
 
-    def __init__(self, *ordered,
-                 arche: bool=False,
-                 bundler: Optional[Bundler] = None,
-                 contents: Optional[Dict[Union[Container, Edge], Union[UserValue, Container]]]=None,
-                 muid: Optional[Muid] = None,
-                 database: Optional[Database]=None,
-                 comment: Optional[str] = None):
+    def __init__(
+                self,
+                muid: Optional[Union[Muid, str]] = None,
+                *,
+                arche: Optional[bool] = None,
+                contents: Optional[Dict[Union[Container, Edge], Union[UserValue, Container]]] = None,
+                database: Optional[Database] = None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
         """
         Constructor for a property definition.
 
         muid: the global id of this directory, created on the fly if None
         db: database send bundles through, or last db instance created if None
         """
-        database = database or Database.get_last()
-
-        if ordered:
-            if isinstance(ordered[0], str):
-                muid = Muid.from_str(ordered[0])
-
         immediate = False
         if bundler is None:
             immediate = True
             bundler = Bundler(comment)
-        if arche:
-            muid = Muid(-1, -1, PROPERTY)
-        elif muid is None:
-            muid = Container._create(PROPERTY, database=database, bundler=bundler)
 
-        Container.__init__(self, muid=muid, database=database)
+        Container.__init__(
+                self,
+                behavior=PROPERTY,
+                muid=muid,
+                arche=arche,
+                database=database,
+                bundler=bundler,
+            )
         if contents:
             self.clear(bundler=bundler)
             self.update(contents, bundler=bundler)
-
         if immediate and len(bundler):
             self._database.bundle(bundler)
 

--- a/python/gink/impl/property.py
+++ b/python/gink/impl/property.py
@@ -15,20 +15,24 @@ class Property(Container):
     BEHAVIOR = PROPERTY
 
     def __init__(
-                self,
-                muid: Optional[Union[Muid, str]] = None,
-                *,
-                arche: Optional[bool] = None,
-                contents: Optional[Dict[Union[Container, Edge], Union[UserValue, Container]]] = None,
-                database: Optional[Database] = None,
-                bundler: Optional[Bundler] = None,
-                comment: Optional[str] = None,
-            ):
+            self,
+            muid: Optional[Union[Muid, str]] = None,
+            *,
+            arche: Optional[bool] = None,
+            contents: Optional[Dict[Union[Container, Edge], Union[UserValue, Container]]] = None,
+            database: Optional[Database] = None,
+            bundler: Optional[Bundler] = None,
+            comment: Optional[str] = None,
+    ):
         """
-        Constructor for a property definition.
+        Constructor for a property.
 
-        muid: the global id of this directory, created on the fly if None
-        db: database send bundles through, or last db instance created if None
+        muid: the global id of this container, created on the fly if None
+        arche: whether this will be the global version of this container (accessible by all databases)
+        contents: prefill the property with a dictionary upon initialization
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
         """
         immediate = False
         if bundler is None:
@@ -42,7 +46,7 @@ class Property(Container):
                 arche=arche,
                 database=database,
                 bundler=bundler,
-            )
+        )
         if contents:
             self.clear(bundler=bundler)
             self.update(contents, bundler=bundler)

--- a/python/gink/impl/sequence.py
+++ b/python/gink/impl/sequence.py
@@ -53,7 +53,7 @@ class Sequence(Container):
         if self._muid.medallion == -1 and self._muid.timestamp == -1:
             identifier = "arche=True"
         else:
-            identifier = repr(str(self._muid))
+            identifier = f"muid={self._muid!r}"
         result = f"""{self.__class__.__name__}({identifier}, contents=["""
         stuffing = [repr(val) for val in self.values(as_of=as_of)]
         as_one_line = result + ", ".join(stuffing) + "])"

--- a/python/gink/impl/sequence.py
+++ b/python/gink/impl/sequence.py
@@ -16,35 +16,29 @@ from .utilities import generate_timestamp
 class Sequence(Container):
     BEHAVIOR = SEQUENCE
 
-    def __init__(self,
-                 *ordered,
-                 contents: Optional[Iterable] = None,
-                 muid: Optional[Muid] = None,
-                 database: Optional[Database] = None,
-                 arche: bool = False,
-                 bundler: Optional[Bundler] = None,
-                 comment: Optional[str] = None,
-                 ):
-        """
-        muid: the global id of this sequence, created on the fly if None
-        database: where to send bundles through, or last db instance created if None
-        """
-        if ordered:
-            if isinstance(ordered[0], str):
-                muid = Muid.from_str(ordered[0])
-        if arche:
-            muid = Muid(-1, -1, SEQUENCE)
-        database = database or Database.get_last()
+    def __init__(
+                self,
+                muid: Optional[Union[Muid, str]] = None,
+                *,
+                arche: Optional[bool] = None,
+                contents: Optional[Iterable] = None,
+                database: Optional[Database]=None,
+                bundler: Optional[Bundler] = None,
+                comment: Optional[str] = None,
+            ):
         immediate = False
         if bundler is None:
             immediate = True
             bundler = Bundler(comment)
-        if muid is None:
-            muid = Container._create(
-                SEQUENCE, database=database, bundler=bundler)
-        Container.__init__(self, muid=muid, database=database)
-        self._muid = muid
-        self._database = database
+
+        Container.__init__(
+                self,
+                behavior=SEQUENCE,
+                muid=muid,
+                arche=arche,
+                database=database,
+                bundler=bundler,
+        )
         if contents is not None:
             self.clear(bundler=bundler)
             self.extend(contents, bundler=bundler)

--- a/python/gink/impl/sequence.py
+++ b/python/gink/impl/sequence.py
@@ -17,15 +17,25 @@ class Sequence(Container):
     BEHAVIOR = SEQUENCE
 
     def __init__(
-                self,
-                muid: Optional[Union[Muid, str]] = None,
-                *,
-                arche: Optional[bool] = None,
-                contents: Optional[Iterable] = None,
-                database: Optional[Database]=None,
-                bundler: Optional[Bundler] = None,
-                comment: Optional[str] = None,
-            ):
+            self,
+            muid: Optional[Union[Muid, str]] = None,
+            *,
+            arche: Optional[bool] = None,
+            contents: Optional[Iterable] = None,
+            database: Optional[Database] = None,
+            bundler: Optional[Bundler] = None,
+            comment: Optional[str] = None,
+    ):
+        """
+        Constructor for a sequence proxy.
+
+        muid: the global id of this container, created on the fly if None
+        arche: whether this will be the global version of this container (accessible by all databases)
+        contents: prefill the sequence with an iterable of values upon initialization
+        database: database send bundles through, or last db instance created if None
+        bundler: the bundler to add changes to, or a new one if None and immediately commits
+        comment: optional comment to add to the bundler
+        """
         immediate = False
         if bundler is None:
             immediate = True

--- a/python/gink/tests/test_database.py
+++ b/python/gink/tests/test_database.py
@@ -155,7 +155,7 @@ def test_dump():
             ks_muid = KeySet(contents=[1, 2, "3"], database=database).get_muid()
             box_muid = Box(contents="box contents", database=database).get_muid()
             ps_muid = PairSet(contents=[(box_muid, ks_muid)], database=database).get_muid()
-            pm_muid = PairMap(contents={(box_muid, ks_muid): "value"}, database=database).get_muid()
+            pm_muid = PairMap(contents={(box_muid, ks_muid): "value", (box_muid, ps_muid): 3}, database=database).get_muid()
             prop_muid = Property(contents={root: "value"}, database=database).get_muid()
             # TODO: group, vertex, verb, edge
 
@@ -172,6 +172,7 @@ def test_dump():
 
             seq = Sequence(muid=seq_muid, database=db2)
             assert seq.at(1)[1] == 2
+            assert seq.at(2)[1] == "3"
 
             ks = KeySet(muid=ks_muid, database=db2)
             assert ks.contains("3")
@@ -184,6 +185,7 @@ def test_dump():
 
             pm = PairMap(muid=pm_muid, database=db2)
             assert pm.get((box_muid, ks_muid)) == "value"
+            assert pm.get((box_muid, ps_muid)) == 3, pm.get((box_muid, ps_muid))
 
             prop = Property(muid=prop_muid, database=db2)
             assert prop.get(root) == "value"


### PR DESCRIPTION
This cleans up  and standardizes the container constructors. Next step will be fuzz tests, but at least the database dumping seems to be mostly working.