### PR TITLE
Property can't dump edge keys

### DIFF
--- a/python/gink/impl/database.py
+++ b/python/gink/impl/database.py
@@ -164,6 +164,7 @@ class Database(Relay):
             behavior = muid.offset
         elif behavior is None:
             container_builder = container_builder or self._store.get_container(muid)
+            assert container_builder is not None, f"no container found for muid: {muid}"
             behavior = getattr(container_builder, "behavior")
         cls = self._container_types.get(behavior)
         if not cls:

--- a/python/gink/tests/test_property.py
+++ b/python/gink/tests/test_property.py
@@ -8,6 +8,7 @@ from ..impl.memory_store import MemoryStore
 from ..impl.lmdb_store import LmdbStore
 from ..impl.database import Database
 from ..impl.bundler import Bundler
+from ..impl.graph import Vertex, Verb
 from ..impl.abstract_store import AbstractStore
 from ..impl.utilities import generate_timestamp
 
@@ -86,3 +87,16 @@ def test_property_ref():
             property.set(directory, directory)
             val = property.get(directory)
             assert val == directory, val
+
+def test_edge_key():
+    for store in [LmdbStore(), MemoryStore()]:
+        with closing(store):
+            database = Database(store=store)
+            v1 = Vertex(database=database)
+            v2 = Vertex(database=database)
+            edge = Verb(database=database).create_edge(sub=v1, obj=v2)
+            property = Property(database=database)
+            property.set(edge, "hello")
+            val = property.get(edge)
+            assert val == "hello", val
+            property.dumps()


### PR DESCRIPTION
Property.items() looks for containers, but an Edge is not a container, nor is it added to the containers database.