### PR TITLE
tweaks to browser tests

### DIFF
--- a/javascript/integration-tests/browser-tests/browser.test.js
+++ b/javascript/integration-tests/browser-tests/browser.test.js
@@ -4,6 +4,8 @@ const { expect } = require('@jest/globals');
 const { getLaunchOptions, sleep } = require("../browser_test_utilities");
 process.chdir(__dirname + "/../..");
 
+jest.retryTimes(2);
+
 it('connect to server and display bundles', async () => {
     const port = 9997;
 
@@ -24,7 +26,6 @@ it('connect to server and display bundles', async () => {
         page.on('console', async e => {
             const args = await Promise.all(e.args().map(a => a.jsonValue()));
         });
-
         await page.goto(`http://localhost:${port}/integration-tests/browser-tests/index.html`);
         await page.waitForSelector('#messages', { timeout: 5000 });
 

--- a/python/gink/tests/test_sequence.py
+++ b/python/gink/tests/test_sequence.py
@@ -74,17 +74,22 @@ def test_reordering():
             for seq in [Sequence.get_global_instance(database), Sequence(muid=Muid(1, 2, 3))]:
                 for letter in "abcxyz":
                     seq.append(letter)
-                    time.sleep(.002)
+                    time.sleep(.01)
                 assert list(seq) == ["a", "b", "c", "x", "y", "z"], list(seq)
                 popped = seq.pop(dest=1)
+                time.sleep(.01)
                 assert list(seq) == ["a", "z", "b", "c", "x", "y"], (list(seq), popped)
                 popped = seq.pop(2, dest=-2)
+                time.sleep(.01)
                 assert list(seq) == ["a", "z", "c", "x", "b", "y"], (list(seq), popped)
                 popped = seq.pop(0, dest=3)
+                time.sleep(.01)
                 assert list(seq) == ["z", "c", "a", "x", "b", "y"], (list(seq), popped)
                 popped = seq.remove("x")
+                time.sleep(.01)
                 assert list(seq) == ["z", "c", "a", "b", "y"], (list(seq), popped)
                 seq.remove("c", dest=seq.index("y"))
+                time.sleep(.01)
                 assert list(seq) == ["z", "a", "b", "c", "y"]
                 popped = seq.pop(1, dest=-1)
                 assert popped == "a", popped


### PR DESCRIPTION
Made the dashboard test a bit less involved, but it still achieves the same thing. Added `jest.retryTimes` to retry the test twice if it fails. This should help make these browser tests less flaky.