### PR TITLE
fixed javascript ints as floating

### DIFF
--- a/javascript/implementation/utils.ts
+++ b/javascript/implementation/utils.ts
@@ -29,7 +29,8 @@ import { hostname, userInfo } from 'os';
 import { TreeMap, MapIterator } from 'jstreemap';
 
 
-import {ready as sodium_ready, crypto_sign_open,
+import {
+    ready as sodium_ready, crypto_sign_open,
     crypto_sign_keypair,
     crypto_sign, crypto_generichash_BYTES, crypto_generichash,
 } from 'libsodium-wrappers';
@@ -258,7 +259,7 @@ export function wrapValue(arg: Value): ValueBuilder {
         return valueBuilder.setOctets(arg);
     }
     if (arg instanceof Date) {
-        return valueBuilder.setTimestamp(arg.getTime()*1000);
+        return valueBuilder.setTimestamp(arg.getTime() * 1000);
     }
     if (arg === null) {
         return valueBuilder.setSpecial(Special.NULL);
@@ -273,10 +274,15 @@ export function wrapValue(arg: Value): ValueBuilder {
         return valueBuilder.setCharacters(arg);
     }
     if (typeof (arg) === "number") {
-        return valueBuilder.setFloating(arg);
+        if (arg.toString().includes(".")) {
+            return valueBuilder.setFloating(arg);
+        }
+        else {
+            return valueBuilder.setInteger(arg.toString());
+        }
     }
     if (typeof (arg) === "bigint") {
-        return valueBuilder.setInteger(arg.toString())
+        return valueBuilder.setInteger(arg.toString());
     }
     if (Array.isArray(arg)) {
         const tupleBuilder = new TupleBuilder();
@@ -627,9 +633,9 @@ export function verifyBundle(signedBundle: Bytes, verifyKey: Bytes) {
     }
 }
 
-export function createKeyPair() : KeyPair {
+export function createKeyPair(): KeyPair {
     const result = crypto_sign_keypair();
-    return {publicKey: result.publicKey, secretKey: result.privateKey}
+    return { publicKey: result.publicKey, secretKey: result.privateKey };
 
     /*
     uncomment for deterministic debugging
@@ -645,7 +651,7 @@ export function createKeyPair() : KeyPair {
 
 export function getSig(bytes: Bytes): number {
     let result = 0;
-    for (let i=0; i<bytes.byteLength;i++) {
+    for (let i = 0; i < bytes.byteLength; i++) {
         result = result ^ bytes[i];
     }
     return result;

--- a/javascript/implementation/utils.ts
+++ b/javascript/implementation/utils.ts
@@ -178,7 +178,10 @@ export function unwrapValue(valueBuilder: ValueBuilder): Value {
         return valueBuilder.getFloating();
     }
     if (valueBuilder.hasInteger()) {
-        return BigInt(valueBuilder.getInteger());
+        if (valueBuilder.getInteger() > Number.MAX_SAFE_INTEGER.toString()) {
+            return BigInt(valueBuilder.getInteger());
+        }
+        return Number(valueBuilder.getInteger());
     }
     if (valueBuilder.hasSpecial()) {
         const special = valueBuilder.getSpecial();
@@ -431,6 +434,9 @@ export function valueToJson(value: Value): string {
     if (type === "string" || type === "number" || value === true || value === false || value === null) {
         return JSON.stringify(value);
     }
+    if (type === "bigint") {
+        return value.toString();
+    }
     if ("function" === typeof value["toISOString"]) {
         return `"${(value as Date).toISOString()}"`;
     }
@@ -442,7 +448,7 @@ export function valueToJson(value: Value): string {
         entries.sort();
         return "{" + entries.map(function (pair) { return `"${pair[0]}":` + valueToJson(pair[1]); }).join(",") + "}";
     }
-    throw new Error(`value not recognized: ${value}`);
+    throw new Error(`value not recognized: ${value} - ${typeof value}`);
 }
 
 export function muidToTuple(muid: Muid): MuidTuple {

--- a/javascript/integration-tests/py-ts-test.js
+++ b/javascript/integration-tests/py-ts-test.js
@@ -21,7 +21,15 @@ process.chdir(__dirname + "/..");
     await sleep(100);
 
     client.send("root.get(3);\n");
-    await client.expect("\n4.0\n", 1000);
+    await client.expect("\n4\n", 1000);
+    await sleep(100);
+
+    server.send("await root.set(4, 4.2);\n");
+    await server.expect("received bundle", 1000);
+    await sleep(100);
+
+    client.send("root.get(4);\n");
+    await client.expect(/.*4.2.*/, 1000);
     await sleep(100);
 
     await client.close();

--- a/javascript/integration-tests/ssl-ts-server-test.js
+++ b/javascript/integration-tests/ssl-ts-server-test.js
@@ -26,7 +26,7 @@ process.chdir(__dirname + "/..");
     await sleep(100);
 
     client.send("root.get(3);\n");
-    await client.expect("\n4.0\n", 1000);
+    await client.expect("\n4\n", 1000);
     await sleep(100);
 
     await client.close();

--- a/javascript/integration-tests/ts-py-test.js
+++ b/javascript/integration-tests/ts-py-test.js
@@ -21,7 +21,7 @@ process.chdir(__dirname + "/..");
 
     await sleep(100);
     client.send("await root.get(3);\n");
-    await client.expect("\n4n\n", 2000);
+    await client.expect("\n4\n", 2000);
 
     await client.close();
     await python.close();

--- a/javascript/unit-tests/Box.test.ts
+++ b/javascript/unit-tests/Box.test.ts
@@ -133,16 +133,21 @@ it('Box.Store', async function () {
 
         var date = new Date();
         await box.set(date);
-        var expectDate = <Date> await box.get();
+        var expectDate = <Date>await box.get();
 
         ensure(isDate(expectDate) && expectDate.getTime() === date.getTime());
 
-        var int = BigInt("137");
+        var bigInt = BigInt("9007199254740992");
+        await box.set(bigInt);
+        var expectBigInt = await box.get();
+        ensure(expectBigInt === bigInt);
+
+        var int = 137;
         await box.set(int);
         var expectInt = await box.get();
         ensure(expectInt === int);
 
-        var floating = 137;
+        var floating = 137.7;
         await box.set(floating);
         var expectFloating = await box.get();
         ensure(expectFloating === floating);


### PR DESCRIPTION
Setting an integer as a value in javascript would cause python to read the value as a float. 

Similarly, javascript gink currently treats all numbers as BigInts.

I think this was intentional, but maybe there is a better way.