### PR TITLE
byName index for TypeScript MemoryStore and IDB byName fix

### DIFF
--- a/javascript/implementation/IndexedDbStore.ts
+++ b/javascript/implementation/IndexedDbStore.ts
@@ -409,24 +409,6 @@ export class IndexedDbStore implements Store {
                     targetList,
                 };
                 if (!(behavior === Behavior.SEQUENCE || behavior === Behavior.EDGE_TYPE)) {
-                    // if (behavior === Behavior.PROPERTY && entry.containerId[0] === -1) {
-                    //     const range = IDBKeyRange.upperBound([containerId, storageKey, [Infinity]]);
-                    //     const search = await trxn.objectStore("entries")
-                    //         .index("by-container-key-placement")
-                    //         .openCursor(range, "prev");
-                    //     console.log("SEARCHING", search);
-
-                    //     while (search && search.value.containerId[0] === -1 && search.value.containerId[2] === Behavior.PROPERTY) {
-                    //         if (search.value.storageKey === storageKey && !search.value.deletion) {
-                    //             await trxn.objectStore("entries").add({
-                    //                 ...search.value,
-                    //                 deletion: true,
-                    //             });
-                    //             break;
-                    //         }
-                    //         search.continue();
-                    //     }
-                    // }
                     const range = IDBKeyRange.bound([containerId, storageKey], [containerId, storageKey, placementId]);
                     const search = await trxn.objectStore("entries").index("by-container-key-placement"
                     ).openCursor(range, "prev");

--- a/javascript/implementation/IndexedDbStore.ts
+++ b/javascript/implementation/IndexedDbStore.ts
@@ -177,11 +177,10 @@ export class IndexedDbStore implements Store {
         await this.ready;
         const trxn = this.getTransaction();
         const secretKey = await trxn.objectStore('secretKeys').get(publicKey);
-        return {secretKey, publicKey};
+        return { secretKey, publicKey };
     }
 
     private clearTransaction() {
-        // console.log("clearing transaction");
         this.transaction = null;
     }
 
@@ -189,7 +188,6 @@ export class IndexedDbStore implements Store {
         const stackString = (new Error()).stack;
         const callerLine = stackString ? stackString.split("\n")[2] : "";
         if (this.transaction === null || this.lastCaller !== callerLine) {
-            // console.log(`creating new transaction for ${callerLine}`)
             this.lastCaller = callerLine;
             this.countTrxns += 1;
             this.transaction = this.wrapped.transaction(
@@ -197,8 +195,6 @@ export class IndexedDbStore implements Store {
                     'containers', 'identities', 'verifyKeys', "secretKeys"],
                 'readwrite');
             this.transaction.done.finally(() => this.clearTransaction());
-        } else {
-            // console.log(`reusing transaction for ${callerLine}`);
         }
         return this.transaction;
     }
@@ -316,16 +312,16 @@ export class IndexedDbStore implements Store {
     addBundle(bundleView: BundleView, claimChain?: boolean): Promise<boolean> {
         if (!this.initialized) throw new Error("need to await on store.ready");
         return this.processingLock.acquireLock().then(async (unlock) => {
-                const trxn = this.getTransaction();
-                const added = await this.addBundleHelper(trxn, bundleView, claimChain);
-                unlock();
-                await trxn.done;
-                return added;
+            const trxn = this.getTransaction();
+            const added = await this.addBundleHelper(trxn, bundleView, claimChain);
+            unlock();
+            await trxn.done;
+            return added;
         });
     }
 
     private async addBundleHelper(trxn: Transaction, bundleView: BundleView, claimChain?: boolean):
-            Promise<boolean> {
+        Promise<boolean> {
         const bundleInfo = bundleView.info;
         const bundleBuilder = bundleView.builder;
         // console.log(`starting addBundleHelper for: ` + JSON.stringify(bundleInfo));
@@ -366,7 +362,7 @@ export class IndexedDbStore implements Store {
         const bundleKey: BundleInfoTuple = bundleInfoToKey(bundleInfo);
         await trxn.objectStore("trxns").add(bundleView.bytes, bundleKey);
         const changesList: Array<ChangeBuilder> = bundleBuilder.getChangesList();
-        for (let index=0; index < changesList.length; index++) {
+        for (let index = 0; index < changesList.length; index++) {
             const offset = index + 1;
             const changeBuilder = changesList[index];
             ensure(offset > 0);
@@ -413,6 +409,24 @@ export class IndexedDbStore implements Store {
                     targetList,
                 };
                 if (!(behavior === Behavior.SEQUENCE || behavior === Behavior.EDGE_TYPE)) {
+                    // if (behavior === Behavior.PROPERTY && entry.containerId[0] === -1) {
+                    //     const range = IDBKeyRange.upperBound([containerId, storageKey, [Infinity]]);
+                    //     const search = await trxn.objectStore("entries")
+                    //         .index("by-container-key-placement")
+                    //         .openCursor(range, "prev");
+                    //     console.log("SEARCHING", search);
+
+                    //     while (search && search.value.containerId[0] === -1 && search.value.containerId[2] === Behavior.PROPERTY) {
+                    //         if (search.value.storageKey === storageKey && !search.value.deletion) {
+                    //             await trxn.objectStore("entries").add({
+                    //                 ...search.value,
+                    //                 deletion: true,
+                    //             });
+                    //             break;
+                    //         }
+                    //         search.continue();
+                    //     }
+                    // }
                     const range = IDBKeyRange.bound([containerId, storageKey], [containerId, storageKey, placementId]);
                     const search = await trxn.objectStore("entries").index("by-container-key-placement"
                     ).openCursor(range, "prev");
@@ -609,7 +623,7 @@ export class IndexedDbStore implements Store {
                 returning.push(entry);
         }
         return returning;
-    }
+    };
 
     /**
      * Returns entry data for a List.  Does it in a single pass rather than using an async generator
@@ -679,7 +693,7 @@ export class IndexedDbStore implements Store {
     async getContainersByName(name: string, asOf?: AsOf): Promise<Muid[]> {
         const asOfTs = asOf ? (await this.asOfToTimestamp(asOf)) : Infinity;
         const desiredSrc: MuidTuple = [-1, -1, Behavior.PROPERTY];
-        const trxn = this.wrapped.transaction(["clearances", "entries"], "readonly");
+        const trxn = this.wrapped.transaction(["clearances", "entries", "removals"], "readonly");
         const clearanceTime = await this.getClearanceTime(<Transaction><unknown>trxn, desiredSrc, asOfTs);
         const lower = [desiredSrc, name];
         const searchRange = IDBKeyRange.lowerBound(lower);
@@ -690,6 +704,11 @@ export class IndexedDbStore implements Store {
         for (; cursor && matches(cursor.key[0], desiredSrc) && cursor.key[1] === name; cursor = await cursor.continue()) {
             const entry = <Entry>cursor.value;
             ensure(entry.behavior === Behavior.PROPERTY);
+            const range = IDBKeyRange.lowerBound([entry.entryId]);
+            const removal = await trxn.objectStore("removals").index("by-removing").openCursor(range);
+            if (removal && removal.value.entryId.toString() === entry.entryId.toString()) {
+                continue;
+            }
             let key: [number, number, number];
             if (Array.isArray(entry.storageKey) && entry.storageKey.length === 3) {
                 key = entry.storageKey;
@@ -711,7 +730,7 @@ export class IndexedDbStore implements Store {
     // for debugging, not part of the api/interface
     async getAllEntries(): Promise<Entry[]> {
         return await this.wrapped.transaction("entries", "readonly").objectStore("entries").getAll();
-    }
+    };
 
     // for debugging, not part of the api/interface
     async getAllRemovals() {

--- a/javascript/unit-tests/Property.test.ts
+++ b/javascript/unit-tests/Property.test.ts
@@ -40,7 +40,7 @@ it('Property.toMap', async function () {
 });
 
 it('Global property sets and gets names', async function () {
-    for (const store of [new MemoryStore(true)]) { //new IndexedDbStore('Global property sets and gets names', true),
+    for (const store of [new IndexedDbStore('Global property sets and gets names', true), new MemoryStore(true)]) {
         const instance = new Database(store);
         await instance.ready;
         const gd = instance.getGlobalDirectory();

--- a/javascript/unit-tests/Property.test.ts
+++ b/javascript/unit-tests/Property.test.ts
@@ -38,3 +38,19 @@ it('Property.toMap', async function () {
         ensure(asObject["-1,-1,10"] === true, Array.from(asMap.keys()).toString());
     }
 });
+
+it('Global property sets and gets names', async function () {
+    for (const store of [new MemoryStore(true)]) { //new IndexedDbStore('Global property sets and gets names', true),
+        const instance = new Database(store);
+        await instance.ready;
+        const gd = instance.getGlobalDirectory();
+        const d2 = await instance.createDirectory();
+        await gd.setName("foo");
+        await d2.setName("bar");
+        const name = await gd.getName();
+        ensure(name === "foo");
+        await gd.setName("changed");
+        const name2 = await gd.getName();
+        ensure(name2 === "changed");
+    }
+});

--- a/javascript/unit-tests/Store.test.ts
+++ b/javascript/unit-tests/Store.test.ts
@@ -188,5 +188,13 @@ export function testStore(implName: string, storeMaker: StoreMaker, replacer?: S
         ensure(bazContainers.length === 1);
         ensure(bazContainers[0].timestamp === seq.timestamp);
         ensure(bazContainers[0].medallion === seq.medallion);
+        await seq.setName("last");
+        const bazContainers2 = await store.getContainersByName("baz");
+        ensure(bazContainers2.length === 0);
+        const lastContainers = await store.getContainersByName("last");
+        ensure(lastContainers.length === 1);
+        ensure(lastContainers[0].timestamp === seq.timestamp);
+        ensure(lastContainers[0].medallion === seq.medallion);
+
     });
 }

--- a/javascript/unit-tests/Store.test.ts
+++ b/javascript/unit-tests/Store.test.ts
@@ -179,5 +179,14 @@ export function testStore(implName: string, storeMaker: StoreMaker, replacer?: S
         ensure(barContainers[0].medallion === d2.medallion);
         ensure(barContainers[1].timestamp === seq.timestamp);
         ensure(barContainers[1].medallion === seq.medallion);
+        await seq.setName("baz");
+        const barContainers2 = await store.getContainersByName("bar");
+        ensure(barContainers2.length === 1);
+        ensure(barContainers2[0].timestamp === d2.timestamp);
+        ensure(barContainers2[0].medallion === d2.medallion);
+        const bazContainers = await store.getContainersByName("baz");
+        ensure(bazContainers.length === 1);
+        ensure(bazContainers[0].timestamp === seq.timestamp);
+        ensure(bazContainers[0].medallion === seq.medallion);
     });
 }

--- a/javascript/unit-tests/Store.test.ts
+++ b/javascript/unit-tests/Store.test.ts
@@ -9,7 +9,6 @@ import {
 } from "./test_utils";
 import {
     muidToBuilder, ensure, wrapValue, matches, wrapKey, signBundle,
-
 } from "../implementation/utils";
 import { Bundler, Database } from "../implementation";
 


### PR DESCRIPTION
getContainersByName uses an index now in MemoryStore.

IndexedDbStore was not handling changed names correctly - the container would be forever found in getContainersByName for its old name.