### PR TITLE
build and testing documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ venv
 data.json
 *.db
 *.db-lock
+.venv

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ all: python/gink/builders javascript/proto javascript/tsc.out javascript/content
 clean:
 	rm -rf javascript/proto javascript/content_root/generated javascript/tsc.out python/gink/builders
 
+rebuild: clean all
+
 running-as-root:
 	bash -c 'test `id -u` -eq 0'
 
@@ -21,7 +23,8 @@ test-javascript:
 test: test-python test-javascript
 
 install-debian-packages: running-as-root
-	apt-get update && apt-get install -y `cat packages.txt | tr '\n' ' '`
+	apt-get update && \
+	apt-get install -y `cat packages.txt | tr '\n' ' '`
 
 install-protoc-gen-js: running-as-root
 	npm install -g protoc-gen-js # https://stackoverflow.com/questions/72572040
@@ -34,6 +37,10 @@ python/gink/builders: $(PROTOS)
 	sed -i -- 's/^from proto import /from . import /' python/gink/proto/* && \
 	touch python/gink/proto/__init__.py && \
 	mv python/gink/proto python/gink/builders
+
+install-python-packages:
+	cd python && \
+	pip install -r requirements.txt
 
 javascript: javascript/proto javascript/tsc.out javascript/content_root/generated
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,138 @@
+# Development
+
+## Build with Docker
+
+To run the entire build process for both TypeScript and Python: \
+Ensure you have Docker installed and you are in the root directory of gink.
+
+```sh
+docker build .
+```
+
+This builds everything and runs tests and linters. This is what is run on push to GitHub.
+
+## Build without Docker
+
+This project uses a Makefile to handle most of the building processes. Before we jump in, ensure you have make, protobuf-compiler, and curl installed. If not, run the following commands: \
+
+### Prerequisites
+
+```sh
+apt-get install make protobuf-compiler curl -y
+```
+
+This process assumes you have npm, pip, and python venv installed.
+
+```sh
+apt-get install npm python3-pip python3-venv -y
+```
+
+### Install dependencies
+
+```sh
+make install-debian-packages && /
+make javascript/node_modules
+```
+
+### Install Python dependencies
+
+```sh
+cd python
+```
+
+Create and activate a Python virtual environment
+
+```sh
+python3 -m venv .venv && \
+source .venv/bin/activate
+```
+
+Install python packages
+
+```sh
+pip3 install -r requirements.txt
+```
+
+### Python
+
+#### Running tests
+
+Ensure you are in the gink/python directory. \
+\
+Run all unit tests
+
+```sh
+nose2
+```
+
+Run a specific unit test
+
+```sh
+nose2 gink.tests.test_module.test_name
+```
+
+Run integration tests
+
+```sh
+./../javascript/integration-tests/run_integration_tests.sh
+```
+
+#### Linting and formatting
+
+Run the mypy linter
+
+```sh
+mypy gink/impl gink/tests
+```
+
+You may need to install missing types with
+
+```sh
+mypy --install-types
+```
+
+Ensure you do not have any lines greater than 120
+
+```sh
+pycodestyle --max-line-length=120 --select=E501 gink/impl/*.py gink/tests/*.py
+
+```
+
+### TypeScript
+
+#### Running tests
+
+Ensure you are in the gink/javascript directory. \
+\
+Unit tests via Node.js
+
+```sh
+npm run test
+```
+
+Unit tests via Browser
+
+```sh
+npm run browser-unit
+```
+
+If this test fails to launch a Chrome process, try setting the CHROME_BIN env variable to your path to Chrome. For example:
+
+```sh
+export CHROME_BIN=/usr/bin/chromium
+```
+
+\
+Integration tests
+
+```sh
+npm run test-integration
+```
+
+Browser integration tests
+
+```sh
+npm run browser-integration
+```
+
+It is recommended you start with running the Node unit tests, then the integration tests. Before you push, run `docker build .` to ensure everthing is working together.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,7 @@
 # Development
 
+This guide currently only walks through setup on Debian.
+
 ## Build with Docker
 
 To run the entire build process for both TypeScript and Python: \
@@ -32,25 +34,6 @@ apt-get install npm python3-pip python3-venv -y
 ```sh
 make install-debian-packages && \
 make javascript/node_modules
-```
-
-### Install Python dependencies
-
-```sh
-cd python
-```
-
-Create and activate a Python virtual environment
-
-```sh
-python3 -m venv .venv && \
-source .venv/bin/activate
-```
-
-Install python packages
-
-```sh
-pip3 install -r requirements.txt
 ```
 
 ### Python

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,7 +13,7 @@ This builds everything and runs tests and linters. This is what is run on push t
 
 ## Build without Docker
 
-This project uses a Makefile to handle most of the building processes. Before we jump in, ensure you have make, protobuf-compiler, and curl installed. If not, run the following commands: \
+This project uses a Makefile to handle most of the building processes. Before we jump in, ensure you have make, protobuf-compiler, and curl installed. If not, run the following commands:
 
 ### Prerequisites
 
@@ -30,7 +30,7 @@ apt-get install npm python3-pip python3-venv -y
 ### Install dependencies
 
 ```sh
-make install-debian-packages && /
+make install-debian-packages && \
 make javascript/node_modules
 ```
 

--- a/javascript/integration-tests/browser_test_utilities.js
+++ b/javascript/integration-tests/browser_test_utilities.js
@@ -1,42 +1,45 @@
+const { existsSync } = require("fs");
+
 function getLaunchOptions(headless = true) {
-    if (headless === true) {
-        headless = "new";
-    } else {
-        headless = false;
+  if (headless === true) {
+    headless = "new";
+  } else {
+    headless = false;
+  }
+  let launchOptions;
+  let chromeLocation = process.env.CHROME_BIN;
+  if (!chromeLocation) {
+    if (existsSync("/usr/bin/chromium")) {
+      chromeLocation = "/usr/bin/chromium";
+    } else if (existsSync("/usr/bin/chromium-browser")) {
+      chromeLocation = "/usr/bin/chromium-browser";
     }
-    let launchOptions;
-    // for this test to run as intended, set env CHROME_BIN
-    // to the path to the chrome binary. Chromium works too.
-    // ex: export CHROME_BIN=/bin/chromium-browser
-    if (process.env.CHROME_BIN) {
-        launchOptions = {
-            executablePath: process.env.CHROME_BIN,
-            headless: headless,
-            args: [
-                "--no-sandbox",
-                "--disable-gpu",
-            ]
-        };
-    }
-    else {
-        // if path to chrome is not specified, try to find it.
-        launchOptions = {
-            product: 'chrome',
-            headless: headless,
-            args: [
-                "--no-sandbox",
-                "--disable-gpu",
-            ]
-        };
-    }
-    return launchOptions;
-};
+  }
+  // for this test to run as intended, set env CHROME_BIN
+  // to the path to the chrome binary. Chromium works too.
+  // ex: export CHROME_BIN=/bin/chromium-browser
+  if (chromeLocation) {
+    launchOptions = {
+      executablePath: chromeLocation,
+      headless: headless,
+      args: ["--no-sandbox", "--disable-gpu"],
+    };
+  } else {
+    // if path to chrome is not specified, try to find it.
+    launchOptions = {
+      product: "chrome",
+      headless: headless,
+      args: ["--no-sandbox", "--disable-gpu"],
+    };
+  }
+  return launchOptions;
+}
 
 async function sleep(ms) {
-    return new Promise(r => setTimeout(r, ms));
-};
+  return new Promise((r) => setTimeout(r, ms));
+}
 
 module.exports = {
-    getLaunchOptions: getLaunchOptions,
-    sleep: sleep
+  getLaunchOptions: getLaunchOptions,
+  sleep: sleep,
 };

--- a/javascript/integration-tests/run_integration_tests.sh
+++ b/javascript/integration-tests/run_integration_tests.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 #set -o errexit
-export PYTHONPATH=../../python
+if [[ -z ${PYTHONPATH} ]]; then
+    export PYTHONPATH=../../python;
+fi
+
 export CURRENT_SAFE_PORT=8080
 cd "$(dirname "$0")"
 

--- a/javascript/integration-tests/run_integration_tests.sh
+++ b/javascript/integration-tests/run_integration_tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #set -o errexit
+export PYTHONPATH=../../python
 export CURRENT_SAFE_PORT=8080
 cd "$(dirname "$0")"
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -37,7 +37,7 @@
     "build": "tsc",
     "test": "jest --testPathPattern=javascript/unit-tests",
     "test-integration": "./integration-tests/run_integration_tests.sh",
-    "browser-unit": "if [[ -z ${CHROME_BIN} ]]; then export CHROME_BIN=/usr/bin/chromium; fi && karma start",
+    "browser-unit": "karma start",
     "browser-integration": "jest --detectOpenHandles browser.test.js dashboard.test.js",
     "browser-performance": "node performance-tests/browser-performance-test.js"
   },

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -36,7 +36,8 @@
     "serve": "./tsc.out/implementation/main.js -l",
     "build": "tsc",
     "test": "jest --testPathPattern=javascript/unit-tests",
-    "browser-unit": "karma start",
+    "test-integration": "./integration-tests/run_integration_tests.sh",
+    "browser-unit": "if [[ -z ${CHROME_BIN} ]]; then export CHROME_BIN=/usr/bin/chromium; fi && karma start",
     "browser-integration": "jest --detectOpenHandles browser.test.js dashboard.test.js",
     "browser-performance": "node performance-tests/browser-performance-test.js"
   },

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,12 @@
+wsproto
+sortedcontainers
+lmdb
+protobuf
+psutil
+authlib
+typeguard
+pynacl
+nose2
+flask
+requests
+mypy

--- a/python/setup.py
+++ b/python/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     extras_require={
         "test": ["nose2", "flask", "requests"],
-        "lint": ["mypy==0.812"],
+        "lint": ["mypy"],
         "performance": ["matplotlib"],
         "docs": [
             "sphinx",


### PR DESCRIPTION
I realized we had no documentation for developers to actually build gink for local development. 

This was actually kind of a nightmare, primarily due to Python packages.

You may have noticed that I unpinned the mypy version we had pinned a while ago. This version of mypy is now impossible to install, at least in my testing through a fresh Debian docker container. It tries to compile a deprecated version of typed_ast that fails every time.

Additionally, using `pip3 install .[test]` through setup.py fails due to us bumping versions using ${VERSION} and sed in our workflows. ${VERSION} is not a valid version. To install this way, the developer would need to change the version to some version number before the install would work. I decided to add a requirements.txt with both necessary and dev dependencies listed.