### PR TITLE
reset for sequence and vertex

### DIFF
--- a/javascript/implementation/Edge.ts
+++ b/javascript/implementation/Edge.ts
@@ -3,9 +3,9 @@ import { Database } from "./Database";
 import { AsOf, EdgeData, Muid, Value, Timestamp } from "./typedefs";
 import { Vertex } from "./Vertex";
 import { EdgeType } from "./EdgeType";
-import { muidToBuilder, entryToEdgeData } from "./utils";
+import { entryToEdgeData } from "./utils";
 import { Bundler } from "./Bundler";
-import { ChangeBuilder, MovementBuilder } from "./builders";
+import { movementHelper } from "./store_utils";
 
 export class Edge extends Addressable {
     private source: Muid;
@@ -56,6 +56,11 @@ export class Edge extends Addressable {
         return this.value;
     }
 
+    /**
+     * NOTE: If this edge has been removed, or if its edgeType has been reset, this method will ALWAYS return false.
+     * If its edgeType has been reset, it has been replaced with a new edge that has the exact same source, target, value,
+     * and properties. Check getEdgesTo and getEdgesFrom on the source and target vertices to find replaced edges.
+     */
     async isAlive(asOf?: AsOf): Promise<boolean> {
         return 0 !== (await this.getEffective(asOf));
     }
@@ -77,6 +82,7 @@ export class Edge extends Addressable {
         purge?: boolean,
         bundlerOrComment?: string | Bundler
     ) {
+        if (!(await this.isAlive())) throw new Error("this edge is not alive.");
         let immediate = false;
         let bundler: Bundler;
         if (bundlerOrComment instanceof Bundler) {
@@ -85,14 +91,7 @@ export class Edge extends Addressable {
             immediate = true;
             bundler = new Bundler(bundlerOrComment);
         }
-        const movementBuilder = new MovementBuilder();
-        movementBuilder.setEntry(muidToBuilder(this.address));
-        if (dest) movementBuilder.setDest(dest);
-        movementBuilder.setContainer(muidToBuilder(this.action));
-        if (purge) movementBuilder.setPurge(true);
-        const changeBuilder = new ChangeBuilder();
-        changeBuilder.setMovement(movementBuilder);
-        bundler.addChange(changeBuilder);
+        await movementHelper(bundler, this.address, this.action, dest, purge);
         if (immediate) {
             await this.database.addBundler(bundler);
         }

--- a/javascript/implementation/EdgeType.ts
+++ b/javascript/implementation/EdgeType.ts
@@ -1,11 +1,29 @@
+import { isEqual } from "lodash";
 import { Database } from "./Database";
 import { Container } from "./Container";
-import { EdgeData, Muid, Value } from "./typedefs";
+import { AsOf, EdgeData, Muid, Value } from "./typedefs";
 import { Behavior, ContainerBuilder } from "./builders";
 import { Bundler } from "./Bundler";
-import { ensure } from "./utils";
+import {
+    ensure,
+    entryToEdgeData,
+    muidToBuilder,
+    muidToString,
+    muidToTuple,
+    muidTupleToMuid,
+    muidTupleToString,
+    strToMuid,
+    wrapKey,
+    wrapValue,
+} from "./utils";
 import { Edge } from "./Edge";
 import { Vertex } from "./Vertex";
+import { EntryBuilder } from "./builders";
+import { ChangeBuilder } from "./builders";
+import { PairBuilder } from "./builders";
+import { construct } from "./factories";
+import { Property } from "./Property";
+import { movementHelper } from "./store_utils";
 
 export class EdgeType extends Container {
     constructor(
@@ -35,5 +53,147 @@ export class EdgeType extends Container {
             value,
         };
         return new Edge(this.database, muid, edgeData);
+    }
+
+    async reset(args?: {
+        toTime?: AsOf;
+        bundlerOrComment?: Bundler | string;
+        skipProperties?: boolean;
+        recurse?: boolean;
+        seen?: Set<string>;
+    }): Promise<void> {
+        const toTime = args?.toTime;
+        const bundlerOrComment = args?.bundlerOrComment;
+        const skipProperties = args?.skipProperties;
+        const recurse = args?.recurse;
+        const seen = recurse ? (args?.seen ?? new Set()) : undefined;
+        if (seen) {
+            seen.add(muidToString(this.address));
+        }
+        let immediate = false;
+        let bundler: Bundler;
+        if (bundlerOrComment instanceof Bundler) {
+            bundler = bundlerOrComment;
+        } else {
+            immediate = true;
+            bundler = new Bundler(bundlerOrComment);
+        }
+        if (!toTime) {
+            // If no time is specified, we are resetting to epoch, which is just a clear
+            this.clear(false, bundler);
+        } else {
+            const entriesThen = await this.database.store.getOrderedEntries(
+                this.address,
+                Infinity,
+                toTime
+            );
+            // Need something subscriptable to compare by position
+            const entriesNow = await this.database.store.getOrderedEntries(
+                this.address,
+                Infinity
+            );
+            for (const [key, entry] of entriesThen) {
+                const placementTupleThen = entry.placementId;
+                const placementNow = await this.database.store.getLocation(
+                    muidTupleToMuid(entry.entryId)
+                );
+                const placementTupleNow = placementNow
+                    ? placementNow.placement
+                    : undefined;
+
+                if (!placementNow) {
+                    // This entry existed then, but has since been deleted
+                    // Need to re-add it to the previous location
+                    const edgeData = entryToEdgeData(entry);
+                    const entryBuilder = new EntryBuilder();
+                    entryBuilder.setContainer(muidToBuilder(this.address));
+                    entryBuilder.setKey(wrapKey(placementTupleThen[0]));
+                    entryBuilder.setBehavior(entry.behavior);
+                    if (entry.value) {
+                        entryBuilder.setValue(wrapValue(entry.value));
+                    }
+                    const pairBuilder = new PairBuilder();
+                    pairBuilder.setLeft(muidToBuilder(edgeData.source));
+                    pairBuilder.setRite(muidToBuilder(edgeData.target));
+                    entryBuilder.setPair(pairBuilder);
+                    const changeBuilder = new ChangeBuilder();
+                    changeBuilder.setEntry(entryBuilder);
+                    const changeMuid = bundler.addChange(changeBuilder);
+                    // Copy properties from the edge that previously existed
+                    const propertiesThen =
+                        await this.database.store.getContainerProperties(
+                            muidTupleToMuid(entry.entryId),
+                            toTime
+                        );
+                    ensure(
+                        isEqual(muidToTuple(this.address), entry.containerId),
+                        "entry's containerId doesn't match this edgeType's address"
+                    );
+                    const newEdge = new Edge(
+                        this.database,
+                        changeMuid,
+                        edgeData
+                    );
+                    for (const [key, value] of propertiesThen.entries()) {
+                        const property = <Property>(
+                            await construct(this.database, strToMuid(key))
+                        );
+                        ensure(
+                            property.behavior === Behavior.PROPERTY,
+                            "constructed container isn't a property?"
+                        );
+
+                        await property.set(newEdge, value, bundler);
+                    }
+                } else {
+                    if (
+                        placementTupleNow &&
+                        placementTupleThen[0] !== placementTupleNow[0]
+                    ) {
+                        // This entry exists, but has been moved
+                        // Need to move it back
+                        await movementHelper(
+                            bundler,
+                            muidTupleToMuid(entry.entryId),
+                            this.address,
+                            placementTupleThen[0],
+                            false
+                        );
+                        // reset the properties of this edge
+                        await this.database.resetContainerProperties(
+                            muidTupleToMuid(entry.entryId),
+                            toTime,
+                            bundler
+                        );
+                    }
+                    // Need to remove the current entry from entriesNow if
+                    // 1) the entry exists but was moved, or 2) the entry is untouched
+                    ensure(
+                        entriesNow.delete(
+                            `${placementTupleNow[0]},${muidTupleToString(entry.entryId)}`
+                        ),
+                        "entry not found in entriesNow"
+                    );
+                }
+            }
+            // We will need to loop through the remaining entries in entriesNow
+            // to delete them, since we know they weren't active at toTime
+            for (const [key, entry] of entriesNow) {
+                await movementHelper(
+                    bundler,
+                    muidTupleToMuid(entry.entryId),
+                    this.address,
+                    undefined,
+                    false
+                );
+            }
+        }
+        if (!skipProperties) {
+            // Reset the properties of this edgeType
+            await this.database.resetContainerProperties(this, toTime, bundler);
+        }
+        if (immediate) {
+            await this.database.addBundler(bundler);
+        }
     }
 }

--- a/javascript/implementation/Group.ts
+++ b/javascript/implementation/Group.ts
@@ -125,10 +125,12 @@ export class Group extends Container {
      * @argument bundlerOrComment Optional bundler or comment to add this change to
      * @argument skipProperties If true, do not reset properties of this container. By default,
      * all properties associated with this container will be reset to the time specified in toTime.
-     * @argument recurse NOTE: THIS FLAG IS IGNORED. Recursive reset for PairSet is not yet implemented,
-     * but this arg needs to be accepted for other containers recursively resetting this one.
-     * @argument seen NOTE: THIS FLAG IS IGNORED. Recursive reset for PairSet is not yet implemented,
-     * but this arg needs to be accepted for other containers recursively resetting this one.
+     * @argument recurse NOTE: THIS FLAG IS IGNORED. Recursive reset for Inclusion-based containers
+     * is not yet implemented, but this arg needs to be accepted for other containers recursively
+     * resetting this one.
+     * @argument seen NOTE: THIS FLAG IS IGNORED. Recursive reset for Inclusion-based containers is
+     * not yet implemented, but this arg needs to be accepted for other containers recursively
+     * resetting this one.
      */
     async reset(args?: {
         toTime?: AsOf;

--- a/javascript/implementation/IndexedDbStore.ts
+++ b/javascript/implementation/IndexedDbStore.ts
@@ -38,6 +38,7 @@ import {
     BundleView,
     KeyPair,
     Value,
+    Placement,
 } from "./typedefs";
 import {
     extractContainerMuid,
@@ -327,6 +328,16 @@ export class IndexedDbStore implements Store {
                 this.wrapped.close();
             }
         }
+    }
+
+    async getLocation(
+        entry: Muid,
+        asOf?: AsOf
+    ): Promise<Placement | undefined> {
+        const asOfTs: Timestamp = asOf
+            ? await this.asOfToTimestamp(asOf)
+            : generateTimestamp();
+        return undefined;
     }
 
     private async asOfToTimestamp(asOf: AsOf): Promise<Timestamp> {

--- a/javascript/implementation/KeySet.ts
+++ b/javascript/implementation/KeySet.ts
@@ -116,10 +116,12 @@ export class KeySet extends Container {
      * @argument bundlerOrComment Optional bundler or comment to add this change to
      * @argument skipProperties If true, do not reset properties of this container. By default,
      * all properties associated with this container will be reset to the time specified in toTime.
-     * @argument recurse NOTE: THIS FLAG IS IGNORED. Recursive reset for PairSet is not yet implemented,
-     * but this arg needs to be accepted for other containers recursively resetting this one.
-     * @argument seen NOTE: THIS FLAG IS IGNORED. Recursive reset for PairSet is not yet implemented,
-     * but this arg needs to be accepted for other containers recursively resetting this one.
+     * @argument recurse NOTE: THIS FLAG IS IGNORED. Recursive reset for Inclusion-based containers
+     * is not yet implemented, but this arg needs to be accepted for other containers recursively
+     * resetting this one.
+     * @argument seen NOTE: THIS FLAG IS IGNORED. Recursive reset for Inclusion-based containers
+     * is not yet implemented, but this arg needs to be accepted for other containers recursively
+     * resetting this one.
      */
     async reset(args?: {
         toTime?: AsOf;

--- a/javascript/implementation/LogBackedStore.ts
+++ b/javascript/implementation/LogBackedStore.ts
@@ -10,6 +10,7 @@ import {
     BundleView,
     KeyPair,
     Value,
+    Placement,
 } from "./typedefs";
 import { BundleInfo, Muid, Entry } from "./typedefs";
 import { MemoryStore } from "./MemoryStore";
@@ -219,6 +220,11 @@ export class LogBackedStore extends LockableLog implements Store {
     async getBundlesProcessed() {
         await this.ready;
         return this.bundlesProcessed;
+    }
+
+    async getLocation(entry: Muid, asOf?: AsOf): Promise<Placement> {
+        await this.ready;
+        return await this.internalStore.getLocation(entry, asOf);
     }
 
     async addBundle(

--- a/javascript/implementation/PairSet.ts
+++ b/javascript/implementation/PairSet.ts
@@ -76,10 +76,12 @@ export class PairSet extends Container {
      * @argument bundlerOrComment Optional bundler or comment to add this change to
      * @argument skipProperties If true, do not reset properties of this container. By default,
      * all properties associated with this container will be reset to the time specified in toTime.
-     * @argument recurse NOTE: THIS FLAG IS IGNORED. Recursive reset for PairSet is not yet implemented,
-     * but this arg needs to be accepted for other containers recursively resetting this one.
-     * @argument seen NOTE: THIS FLAG IS IGNORED. Recursive reset for PairSet is not yet implemented,
-     * but this arg needs to be accepted for other containers recursively resetting this one.
+     * @argument recurse NOTE: THIS FLAG IS IGNORED. Recursive reset for Inclusion-based containers
+     * is not yet implemented, but this arg needs to be accepted for other containers recursively
+     * resetting this one.
+     * @argument seen NOTE: THIS FLAG IS IGNORED. Recursive reset for Inclusion-based containers
+     * is not yet implemented, but this arg needs to be accepted for other containers recursively
+     * resetting this one.
      */
     async reset(args?: {
         toTime?: AsOf;

--- a/javascript/implementation/Sequence.ts
+++ b/javascript/implementation/Sequence.ts
@@ -1,4 +1,3 @@
-import { isEqual } from "lodash";
 import { Database } from "./Database";
 import { Container } from "./Container";
 import { AsOf, Entry, Muid, Value } from "./typedefs";
@@ -144,10 +143,16 @@ export class Sequence extends Container {
                     entryBuilder.setContainer(muidToBuilder(this.address));
                     entryBuilder.setKey(wrapKey(placementTupleThen[0]));
                     entryBuilder.setBehavior(entry.behavior);
-                    entryBuilder.setValue(wrapValue(entry.value));
-                    if (entry.pointeeList)
-                        entryBuilder.setPointee(entry.pointeeList[0]);
+                    if (entry.value !== undefined) {
+                        entryBuilder.setValue(wrapValue(entry.value));
+                    }
 
+                    if (entry.pointeeList.length > 0) {
+                        const pointeeMuid = muidTupleToMuid(
+                            entry.pointeeList[0]
+                        );
+                        entryBuilder.setPointee(muidToBuilder(pointeeMuid));
+                    }
                     const changeBuilder = new ChangeBuilder();
                     changeBuilder.setEntry(entryBuilder);
                     bundler.addChange(changeBuilder);

--- a/javascript/implementation/Sequence.ts
+++ b/javascript/implementation/Sequence.ts
@@ -175,7 +175,7 @@ export class Sequence extends Container {
                     );
                 }
                 // Finally, if the previous entry was a container, recusively reset it
-                if (recurse && entry.pointeeList.length > 0) {
+                if (seen && entry.pointeeList.length > 0) {
                     const pointeeMuid = muidTupleToMuid(entry.pointeeList[0]);
                     if (!seen.has(muidToString(pointeeMuid))) {
                         const container = await construct(

--- a/javascript/implementation/Store.ts
+++ b/javascript/implementation/Store.ts
@@ -81,9 +81,18 @@ export interface Store {
     // TODO maybe return an actual data structure ?
     getContainerBytes: (address: Muid) => Promise<Bytes | undefined>;
 
+    /**
+     * In ordered container types (Sequence and EdgeType), entries may be moved around.
+     * This method returns information about the current effective time, which may
+     * be different from the timestamp of the entry itself.
+     * @param entry the muid of the entry
+     * @param asOf optional timestamp to look back to
+     * @returns an object with the container muid, key, and the placement id.
+     */
     getLocation: (entry: Muid, asOf?: AsOf) => Promise<Placement | undefined>;
 
     getEntryById(entryMuid: Muid, asOf?: AsOf): Promise<Entry | undefined>;
+
     getEntryByKey(
         container: Muid,
         key?: ScalarKey | Muid | [Muid, Muid],
@@ -100,6 +109,7 @@ export interface Store {
         through: number,
         asOf?: AsOf
     ): Promise<Map<string, Entry>>;
+
     getEntriesBySourceOrTarget(
         vertex: Muid,
         source: boolean,

--- a/javascript/implementation/Store.ts
+++ b/javascript/implementation/Store.ts
@@ -12,6 +12,7 @@ import {
     BroadcastFunc,
     KeyPair,
     Value,
+    Placement,
 } from "./typedefs";
 
 export interface Store {
@@ -79,6 +80,8 @@ export interface Store {
      */
     // TODO maybe return an actual data structure ?
     getContainerBytes: (address: Muid) => Promise<Bytes | undefined>;
+
+    getLocation: (entry: Muid, asOf?: AsOf) => Promise<Placement | undefined>;
 
     getEntryById(entryMuid: Muid, asOf?: AsOf): Promise<Entry | undefined>;
     getEntryByKey(

--- a/javascript/implementation/builders.d.ts
+++ b/javascript/implementation/builders.d.ts
@@ -105,7 +105,6 @@ export class EntryBuilder extends ImplementedMessage {
     getContainer(): MuidBuilder;
     hasEffective(): boolean;
     getEffective(): number;
-    setEffective(number);
     getExpiry(): number;
     setDescribing(MuidBuilder);
     getDescribing(): MuidBuilder;

--- a/javascript/implementation/builders.d.ts
+++ b/javascript/implementation/builders.d.ts
@@ -105,6 +105,7 @@ export class EntryBuilder extends ImplementedMessage {
     getContainer(): MuidBuilder;
     hasEffective(): boolean;
     getEffective(): number;
+    setEffective(number);
     getExpiry(): number;
     setDescribing(MuidBuilder);
     getDescribing(): MuidBuilder;

--- a/javascript/implementation/store_utils.ts
+++ b/javascript/implementation/store_utils.ts
@@ -24,8 +24,10 @@ import {
     dehydrate,
     intToHex,
     muidTupleToString,
+    muidToBuilder,
 } from "./utils";
 import { Container } from "./Container";
+import { Bundler } from "./Bundler";
 
 /**
  *
@@ -112,6 +114,32 @@ export function extractMovement(
         dest: movementBuilder.getDest(),
         purge: movementBuilder.getPurge(),
     };
+}
+
+/**
+ * Bundles a movement change into the provided bundler
+ * @param bundler The bundler to add the change to
+ * @param entryMuid The muid of the entry to move
+ * @param containerMuid The muid of the container that holds this entry
+ * @param dest Destination to move the entry to. If omitted, the entry is removed.
+ * @param purge Purge the entry from the internal store?
+ */
+export async function movementHelper(
+    bundler: Bundler,
+    entryMuid: Muid,
+    containerMuid: Muid,
+    dest?: number,
+    purge?: boolean
+): Promise<void> {
+    ensure(bundler instanceof Bundler);
+    const movementBuilder = new MovementBuilder();
+    movementBuilder.setEntry(muidToBuilder(entryMuid));
+    if (dest) movementBuilder.setDest(dest);
+    movementBuilder.setContainer(muidToBuilder(containerMuid));
+    if (purge) movementBuilder.setPurge(true);
+    const changeBuilder = new ChangeBuilder();
+    changeBuilder.setMovement(movementBuilder);
+    bundler.addChange(changeBuilder);
 }
 
 export function extractContainerMuid(

--- a/javascript/implementation/typedefs.ts
+++ b/javascript/implementation/typedefs.ts
@@ -37,6 +37,11 @@ export type Cookies = Map<string, string>;
 export type Indexable = MuidTuple;
 export type ActorId = number; // process ID on the server side, something more complex in the browser
 export type StorageKey = ScalarKey | MuidTuple | [MuidTuple, MuidTuple] | [];
+export type Placement = {
+    container: MuidTuple;
+    key: StorageKey;
+    placement: MuidTuple;
+};
 
 export interface BundleListener {
     (bundle: BundleView): Promise<void>;

--- a/javascript/implementation/utils.ts
+++ b/javascript/implementation/utils.ts
@@ -425,6 +425,15 @@ export function muidTupleToString(muidTuple: MuidTuple): string {
     return `${timestamp}-${medallion}-${offset}`;
 }
 
+export function strToMuidTuple(value: string): MuidTuple {
+    const nums = value.split("-");
+    return [
+        muidHexToInt(nums[0]),
+        muidHexToInt(nums[1]),
+        muidHexToInt(nums[2]),
+    ];
+}
+
 export function strToMuid(value: string): Muid {
     const nums = value.split("-");
     return {

--- a/javascript/unit-tests/Sequence.test.ts
+++ b/javascript/unit-tests/Sequence.test.ts
@@ -437,9 +437,26 @@ it("List.reset", async function () {
         await dir.set("foo", "baz");
         await box.set("changed!");
         await seq.push(1);
+        const beforeReset = generateTimestamp();
         await seq.reset({ toTime: afterBox, recurse: true });
         ensure((await seq.size()) === 1);
         ensure((await box.get()) instanceof Directory);
         ensure((await dir.get("foo")) === "bar");
+
+        // Reset back
+        await seq.reset({ toTime: beforeReset, recurse: true });
+        ensure((await seq.size()) === 2);
+        ensure((await seq.at(1)) === 1);
+        ensure((await box.get()) === "changed!");
+        // This will not have been reset, since the directory was not held
+        // in the box at the time of the reset
+        ensure((await dir.get("foo")) === "bar");
+
+        await seq.shift(); // Remove the box
+
+        await seq.reset({ toTime: beforeReset, recurse: true });
+        ensure((await seq.size()) === 2);
+        ensure((await seq.at(1)) === 1);
+        ensure((await box.get()) === "changed!");
     }
 });

--- a/javascript/unit-tests/Sequence.test.ts
+++ b/javascript/unit-tests/Sequence.test.ts
@@ -437,7 +437,7 @@ it("List.reset", async function () {
         await dir.set("foo", "baz");
         await box.set("changed!");
         await seq.push(1);
-        await seq.reset({ toTime: afterBox });
+        await seq.reset({ toTime: afterBox, recurse: true });
         ensure((await seq.size()) === 1);
         ensure((await box.get()) instanceof Directory);
         ensure((await dir.get("foo")) === "bar");

--- a/javascript/unit-tests/Sequence.test.ts
+++ b/javascript/unit-tests/Sequence.test.ts
@@ -7,6 +7,7 @@ import {
     Sequence,
     Muid,
     Value,
+    Directory,
 } from "../implementation";
 import { ensure, matches, generateTimestamp } from "../implementation/utils";
 
@@ -424,5 +425,21 @@ it("List.reset", async function () {
         ensure((await seq.size()) === 10);
         ensure((await seq.at(0)) === 0);
         ensure((await seq.at(9)) === 9);
+
+        // Test recursive reset
+        await seq.clear();
+        const box = await instance.createBox();
+        const dir = await instance.createDirectory();
+        await box.set(dir);
+        await dir.set("foo", "bar");
+        await seq.push(box);
+        const afterBox = generateTimestamp();
+        await dir.set("foo", "baz");
+        await box.set("changed!");
+        await seq.push(1);
+        await seq.reset({ toTime: afterBox });
+        ensure((await seq.size()) === 1);
+        ensure((await box.get()) instanceof Directory);
+        ensure((await dir.get("foo")) === "bar");
     }
 });

--- a/javascript/unit-tests/Sequence.test.ts
+++ b/javascript/unit-tests/Sequence.test.ts
@@ -364,7 +364,7 @@ it("extend", async function () {
 
 it("List.reset", async function () {
     for (const store of [
-        // new IndexedDbStore("list-reset", true),
+        new IndexedDbStore("list-reset", true),
         new MemoryStore(true),
     ]) {
         const instance = new Database(store);
@@ -401,7 +401,7 @@ it("List.reset", async function () {
         ensure((await prop2.get(seq)) === undefined);
 
         await seq.reset({ toTime: afterSecond, skipProperties: true });
-        ensure((await seq.size()) === 10);
+        ensure((await seq.size()) === 10, (await seq.size()).toString());
         ensure((await seq.at(0)) === 0);
         ensure((await seq.at(9)) === 9);
         ensure((await prop1.get(seq)) === undefined);
@@ -417,5 +417,12 @@ it("List.reset", async function () {
         ensure((await seq.at(9)) === 9);
         ensure((await prop1.get(seq)) === undefined);
         ensure((await prop2.get(seq)) === undefined);
+
+        await seq.pop(0);
+        ensure((await seq.size()) === 9);
+        await seq.reset({ toTime: afterSecond, skipProperties: true });
+        ensure((await seq.size()) === 10);
+        ensure((await seq.at(0)) === 0);
+        ensure((await seq.at(9)) === 9);
     }
 });

--- a/javascript/unit-tests/Sequence.test.ts
+++ b/javascript/unit-tests/Sequence.test.ts
@@ -364,7 +364,7 @@ it("extend", async function () {
 
 it("List.reset", async function () {
     for (const store of [
-        new IndexedDbStore("list-reset", true),
+        // new IndexedDbStore("list-reset", true),
         new MemoryStore(true),
     ]) {
         const instance = new Database(store);
@@ -399,6 +399,17 @@ it("List.reset", async function () {
         ensure((await seq.size()) === 0);
         ensure((await prop1.get(seq)) === undefined);
         ensure((await prop2.get(seq)) === undefined);
+
+        await seq.reset({ toTime: afterSecond, skipProperties: true });
+        ensure((await seq.size()) === 10);
+        ensure((await seq.at(0)) === 0);
+        ensure((await seq.at(9)) === 9);
+        ensure((await prop1.get(seq)) === undefined);
+        ensure((await prop2.get(seq)) === undefined);
+
+        await seq.push(10);
+        await seq.push(11);
+        await seq.move(10, 0);
 
         await seq.reset({ toTime: afterSecond, skipProperties: true });
         ensure((await seq.size()) === 10);

--- a/javascript/unit-tests/graph.test.ts
+++ b/javascript/unit-tests/graph.test.ts
@@ -1,10 +1,4 @@
-import {
-    Database,
-    IndexedDbStore,
-    Vertex,
-    EdgeType,
-    MemoryStore,
-} from "../implementation";
+import { Database, IndexedDbStore, MemoryStore } from "../implementation";
 import { ensure, generateTimestamp } from "../implementation/utils";
 
 it("isAlive and remove", async function () {
@@ -63,12 +57,6 @@ it("from_to", async function () {
         const edge22 = await edge_type.createEdge(vertex2, vertex2);
         const edge23 = await edge_type.createEdge(vertex2, vertex3);
 
-        /*
-        const entries = await store.getAllEntries();
-        for (let i = 0; i< entries.length; i++) {
-            console.log(JSON.stringify(entries[i]));
-        }
-         */
         const edgesTo2 = await vertex2.getEdgesTo();
         ensure(edgesTo2.length === 2, `wtf: ${edgesTo2.length}`);
         ensure(edgesTo2[0].equals(edge12) || edgesTo2[0].equals(edge22));
@@ -101,13 +89,15 @@ it("edge_reorder", async function () {
         const b = await instance.createVertex();
 
         const p = await instance.createEdgeType();
+        const prop = await instance.createProperty();
 
         const beforeX = generateTimestamp();
         const x = await p.createEdge(a, b);
         const y = await p.createEdge(a, b);
+        await prop.set(y, "foo");
         const afterX = generateTimestamp();
         const entries = await store.getAllEntries();
-        ensure(entries.length === 2);
+        ensure(entries.length === 3);
         const edges1 = await a.getEdgesFrom();
         ensure(
             edges1.length === 2 && edges1[0].equals(x) && edges1[1].equals(y),
@@ -117,10 +107,13 @@ it("edge_reorder", async function () {
         await y.remove(beforeX);
 
         const edges2 = await a.getEdgesFrom();
+        const newY = edges2[0];
         ensure(
-            edges2.length === 2 && edges2[0].equals(y) && edges2[1].equals(x),
+            edges2.length === 2 && newY.equals(y) && edges2[1].equals(x),
             edges2.toString()
         );
+        // make sure property gets set again on "new" edge
+        ensure((await prop.get(newY)) === "foo");
 
         const edges3 = await b.getEdgesTo(afterX);
         ensure(
@@ -163,5 +156,95 @@ it("vertex reset", async function () {
         ensure(!(await vertex.isAlive()));
         ensure((await prop1.get(vertex)) === "foo");
         ensure((await prop2.get(vertex)) === "bar");
+    }
+});
+
+it("edge_type reset", async function () {
+    for (const store of [
+        new IndexedDbStore("edgetype reset", true),
+        new MemoryStore(true),
+    ]) {
+        const instance = new Database(store);
+        await instance.ready;
+
+        const vertex1 = await instance.createVertex();
+        const vertex2 = await instance.createVertex();
+        const vertex3 = await instance.createVertex();
+        const edgeType = await instance.createEdgeType();
+        const edge1 = await edgeType.createEdge(vertex1, vertex2);
+        const edge2 = await edgeType.createEdge(vertex2, vertex1);
+        const prop1 = await instance.createProperty();
+        const prop2 = await instance.createProperty();
+        await prop1.set(edgeType, "foo");
+        await prop2.set(edgeType, "bar");
+        const afterInit = generateTimestamp();
+        const edge3 = await edgeType.createEdge(vertex1, vertex3);
+        await prop1.set(edgeType, "foo");
+        await prop2.set(edgeType, "baz");
+        const afterSecond = generateTimestamp();
+
+        await edgeType.reset({ toTime: afterInit });
+        const edgesFrom1 = await vertex1.getEdgesFrom();
+        const edgesFrom2 = await vertex2.getEdgesFrom();
+        ensure(edgesFrom1.length === 1);
+        ensure(edgesFrom2.length === 1);
+        ensure((await prop1.get(edgeType)) === "foo");
+        ensure((await prop2.get(edgeType)) === "bar");
+
+        await edge1.remove();
+        ensure((await vertex1.getEdgesFrom()).length === 0);
+
+        await edgeType.reset({ toTime: afterSecond, skipProperties: true });
+        ensure((await vertex1.getEdgesFrom()).length === 2);
+        ensure((await vertex2.getEdgesFrom()).length === 1);
+        ensure((await vertex3.getEdgesTo()).length === 1);
+        ensure((await prop1.get(edgeType)) === "foo");
+        ensure((await prop2.get(edgeType)) === "bar");
+    }
+});
+
+it("edge property restoration", async function () {
+    for (const store of [
+        new IndexedDbStore("edge property restore", true),
+        new MemoryStore(true),
+    ]) {
+        const instance = new Database(store);
+        await instance.ready;
+
+        const vertex1 = await instance.createVertex();
+        const vertex2 = await instance.createVertex();
+        const edgeType = await instance.createEdgeType();
+        const edge1 = await edgeType.createEdge(vertex1, vertex2);
+        const e1muid = (await vertex1.getEdgesFrom())[0].address;
+        const prop1 = await instance.createProperty();
+        const prop2 = await instance.createProperty();
+        await prop1.set(edge1, "foo");
+        await prop2.set(edge1, "bar");
+        const beforeRemove = generateTimestamp();
+        await edge1.remove();
+        await edgeType.reset({ toTime: beforeRemove });
+        const edges = await vertex1.getEdgesFrom();
+        ensure(edges.length === 1);
+        ensure(edges[0].address.timestamp !== e1muid.timestamp);
+        ensure((await prop1.get(edges[0])) === "foo");
+        ensure((await prop2.get(edges[0])) === "bar");
+
+        await prop1.set(edges[0], "baz");
+        ensure((await prop1.get(edges[0])) === "baz");
+
+        await edgeType.reset({ toTime: beforeRemove });
+        const edges2 = await vertex1.getEdgesFrom();
+        ensure(edges2.length === 1);
+        ensure((await prop1.get(edges2[0])) === "foo");
+        ensure((await prop2.get(edges2[0])) === "bar");
+
+        await prop2.delete(edges[0]);
+        ensure((await prop2.get(edges[0])) === undefined);
+
+        await edgeType.reset({ toTime: beforeRemove });
+        const edges3 = await vertex1.getEdgesFrom();
+        ensure(edges3.length === 1);
+        ensure((await prop1.get(edges3[0])) === "foo");
+        ensure((await prop2.get(edges3[0])) === "bar");
     }
 });


### PR DESCRIPTION
Something I need clarification on for all of this reset functionality:

For recursively resetting sub-containers, are we only talking about the containers that were there at toTime? Or are we resetting all containers there now as well?

I have been assuming we just reset the containers that were there at the time we are resetting to, rather than if a container is a current entry.

**I'm going to implement EdgeType reset in another PR since this one is getting lengthy**