### PR TITLE
adjusted timeouts for displacer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROTOS=$(wildcard proto/*.proto)
 export PATH := ./javascript/node_modules/.bin/:./node_modules/.bin/:$(PATH)
 PYTHON_CODE=$(wildcard python/*.py python/gink/impl/*.py python/gink/tests/*.py python/gink/*.py)
 
-all: python/gink/builders javascript/proto javascript/tsc.out javascript/content_root/generated
+all: python/gink/builders javascript/node_modules javascript/proto javascript/tsc.out javascript/content_root/generated
 
 .PHONY: clean running-as-root on-main-and-clean install-dependencies install-debian-packages javascript push-base
 

--- a/javascript/integration-tests/Expector.js
+++ b/javascript/integration-tests/Expector.js
@@ -14,7 +14,11 @@ module.exports = class Expector {
         this.expecting = null;
         this.closing = null;
         this.verbose = verbose;
+        this._closed = null; // { code, signal } once process has exited
         this.proc = spawn(program, args, options);
+        this.proc.on("close", (code, signal) => {
+            this._closed = { code, signal };
+        });
         const appender = this.notify.bind(this);
         this.proc.stdout.on("data", appender);
         this.proc.stderr.on("data", appender);
@@ -50,16 +54,54 @@ module.exports = class Expector {
     /**
      * Wait for the "what" string to appear in the stdout or stderr of the program,
      * but reject the promise if timeout happens before the expected string appears.
+     * If the process exits while waiting, rejects with a message that the process
+     * has exited (so the expected string can never appear).
      */
-    async expect(what, timeout = 1000) {
+    async expect(what, timeout = 5000) {
         await this.spawned;
+        if (this._closed) {
+            const { code, signal } = this._closed;
+            const exitInfo =
+                signal != null ? `signal=${signal}` : `code=${code}`;
+            throw new Error(
+                `process already exited (${exitInfo}); expected ${what}, had ${this.captured}`
+            );
+        }
         this.expecting = what;
         const thisExpector = this;
         const returning = new Promise((resolve, reject) => {
-            thisExpector.onHit = resolve;
-            setTimeout(() => {
-                reject(`expected ${what}, had ${thisExpector.captured}`);
+            let settled = false;
+            const cleanup = () => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeoutId);
+                thisExpector.proc.removeListener("close", onExit);
+            };
+            const timeoutId = setTimeout(() => {
+                if (thisExpector.expecting) {
+                    thisExpector.expecting = null;
+                    cleanup();
+                    reject(`expected ${what}, had ${thisExpector.captured}`);
+                }
             }, timeout);
+            const onExit = (code, signal) => {
+                if (thisExpector.expecting) {
+                    thisExpector.expecting = null;
+                    cleanup();
+                    const exitInfo =
+                        signal != null
+                            ? `signal=${signal}`
+                            : `code=${code}`;
+                    reject(
+                        `process exited (${exitInfo}) before expected string was seen; expected ${what}, had ${thisExpector.captured}`
+                    );
+                }
+            };
+            thisExpector.proc.once("close", onExit);
+            thisExpector.onHit = (match) => {
+                cleanup();
+                resolve(match);
+            };
         });
         this.notify();
         return returning;
@@ -81,7 +123,7 @@ module.exports = class Expector {
      * kill that shell, and will leave programs started by that shell alive.
      * TODO(https://github.com/google/gink/issues/30): kill decendants
      */
-    async close(timeout = 1000) {
+    async close(timeout = 5000) {
         await this.spawned;
         if (!this.closing) {
             this.closing = new Promise((resolve, reject) => {

--- a/javascript/integration-tests/Expector.js
+++ b/javascript/integration-tests/Expector.js
@@ -121,7 +121,7 @@ module.exports = class Expector {
      * Kill the underlying program, and resolve once the program has closed.
      * Note that the constructor starts a shell command, so this program will
      * kill that shell, and will leave programs started by that shell alive.
-     * TODO(https://github.com/google/gink/issues/30): kill decendants
+     * TODO(https://github.com/google/gink/issues/30): kill descendants
      */
     async close(timeout = 5000) {
         await this.spawned;

--- a/javascript/integration-tests/accumulator-reuse-test.js
+++ b/javascript/integration-tests/accumulator-reuse-test.js
@@ -24,7 +24,7 @@ process.exit(0);
         const args = ["-um", "gink", TEST_DB_PATH, "--interactive"];
         const python1 = new Expector("python3", args);
         python1.send("1+2\n");
-        await python1.expect("3", 2000);
+        await python1.expect("3");
         console.log("got three");
         await sleep(100);
         //python1.send("from gink import * \n")
@@ -38,22 +38,22 @@ process.exit(0);
         python1.send("accum.get()\n");
         await sleep(1000);
         console.log(`captured = ${JSON.stringify(python1.captured)}`);
-        await python1.expect("3.7", 2000);
+        await python1.expect("3.7");
         await python1.close();
         console.log("finished first process");
 
         const cobra = new Expector("python3", args);
         cobra.send("2+3\n");
-        await cobra.expect("5", 2000);
+        await cobra.expect("5");
         console.log("got 5");
         cobra.send("accum = root['accum']\n");
         await sleep(100);
         cobra.send("accum.get()\n");
-        await cobra.expect("3.7", 2000);
+        await cobra.expect("3.7");
         cobra.send("accum += 7.4\n");
         await sleep(100);
         cobra.send("accum.get()\n");
-        await cobra.expect("11.1", 2000);
+        await cobra.expect("11.1");
         process.exit(0);
     } catch (error) {
         console.log(`error = ${error}`);

--- a/javascript/integration-tests/api-test.js
+++ b/javascript/integration-tests/api-test.js
@@ -25,7 +25,7 @@ process.chdir(__dirname + "/..");
             },
         },
     );
-    await server.expect("listening", 2000);
+    await server.expect("listening");
     await sleep(1000);
 
     // Try to put without auth token
@@ -36,7 +36,7 @@ process.chdir(__dirname + "/..");
         3,
         `http://127.0.0.1:${port}/key1`,
     ]);
-    await putFail.expect("Bad auth token.", 2000);
+    await putFail.expect("Bad auth token.");
 
     // PUT a number in json format
     const put1 = new Expector("curl", [
@@ -50,7 +50,7 @@ process.chdir(__dirname + "/..");
         3,
         `http://127.0.0.1:${port}/key1`,
     ]);
-    await put1.expect("Entry updated or created.", 2000);
+    await put1.expect("Entry updated or created.");
 
     // PUT a dict in json format
     const put2 = new Expector("curl", [
@@ -68,7 +68,7 @@ process.chdir(__dirname + "/..");
         })}`,
         `http://127.0.0.1:${port}/key2`,
     ]);
-    await put2.expect("Entry updated or created.", 2000);
+    await put2.expect("Entry updated or created.");
 
     // PUT plain text
     const put3 = new Expector("curl", [
@@ -82,7 +82,7 @@ process.chdir(__dirname + "/..");
         `plain text test`,
         `http://127.0.0.1:${port}/key3`,
     ]);
-    await put3.expect("Entry updated or created.", 2000);
+    await put3.expect("Entry updated or created.");
 
     // PUT binary data
     const put4 = new Expector("curl", [
@@ -96,7 +96,7 @@ process.chdir(__dirname + "/..");
         "10001010",
         `http://127.0.0.1:${port}/key4`,
     ]);
-    await put4.expect("Entry updated or created.", 2000);
+    await put4.expect("Entry updated or created.");
 
     // PUT None
     const put5 = new Expector("curl", [
@@ -106,7 +106,7 @@ process.chdir(__dirname + "/..");
         "Authorization: Bearer abcd",
         `http://127.0.0.1:${port}/key5`,
     ]);
-    await put5.expect("Entry updated or created.", 2000);
+    await put5.expect("Entry updated or created.");
 
     const get1 = new Expector("curl", [
         "-X",
@@ -115,7 +115,7 @@ process.chdir(__dirname + "/..");
         "Authorization: Bearer abcd",
         `http://127.0.0.1:${port}/key1`,
     ]);
-    await get1.expect(3, 2000);
+    await get1.expect(3);
 
     const get2 = new Expector("curl", [
         "-X",
@@ -126,7 +126,7 @@ process.chdir(__dirname + "/..");
     ]);
     const regex =
         /{\s*"a"\s*:\s*1\s*,\s*"b"\s*:\s*2\s*,\s*"c"\s*:\s*"test"\s*}/;
-    await get2.expect(regex, 2000);
+    await get2.expect(regex);
 
     const get3 = new Expector("curl", [
         "-X",
@@ -135,7 +135,7 @@ process.chdir(__dirname + "/..");
         "Authorization: Bearer abcd",
         `http://127.0.0.1:${port}/key3`,
     ]);
-    await get3.expect("plain text test", 2000);
+    await get3.expect("plain text test");
 
     const get4 = new Expector("curl", [
         "-X",
@@ -144,7 +144,7 @@ process.chdir(__dirname + "/..");
         "Authorization: Bearer abcd",
         `http://127.0.0.1:${port}/key4`,
     ]);
-    await get4.expect("10001010", 2000);
+    await get4.expect("10001010");
 
     const get5 = new Expector("curl", [
         "-X",
@@ -153,7 +153,7 @@ process.chdir(__dirname + "/..");
         "Authorization: Bearer abcd",
         `http://127.0.0.1:${port}/key5`,
     ]);
-    await get5.expect("null", 2000);
+    await get5.expect("null");
 
     const delete4 = new Expector("curl", [
         "-X",
@@ -162,7 +162,7 @@ process.chdir(__dirname + "/..");
         "Authorization: Bearer abcd",
         `http://127.0.0.1:${port}/key4`,
     ]);
-    await delete4.expect("Entry deleted.", 2000);
+    await delete4.expect("Entry deleted.");
 
     const get4Again = new Expector("curl", [
         "-X",
@@ -171,7 +171,7 @@ process.chdir(__dirname + "/..");
         "Authorization: Bearer abcd",
         `http://127.0.0.1:${port}/key4`,
     ]);
-    await get4Again.expect("Entry not found.", 2000);
+    await get4Again.expect("Entry not found.");
 
     await server.close();
     console.log("finished!");

--- a/javascript/integration-tests/authentication-test.js
+++ b/javascript/integration-tests/authentication-test.js
@@ -13,21 +13,21 @@ let client;
         ["-l", port, "--auth-token", "abc", "--verbose"],
         { ...process.env },
     );
-    await server.expect("node.gink", 2000);
+    await server.expect("node.gink");
     client = new Expector("./tsc.out/implementation/main.js", ["--verbose"]);
-    await client.expect("node.gink", 2000);
+    await client.expect("node.gink");
     console.log("all ready");
 
     client.send(
         `void database.connectTo('ws://127.0.0.1:${port}', {onError: (err)=>console.error('unable to connect')});\n`,
     );
-    await client.expect("unable to connect", 2000);
+    await client.expect("unable to connect");
     console.log("saw rejection");
 
     client.send(
         `void database.connectTo('ws://127.0.0.1:${port}', {authToken:'abc', onError: (err)=>console.error(err, 'unable to connect')});\n`,
     );
-    await server.expect("Connection accepted.", 2000);
+    await server.expect("Connection accepted.");
     console.log("correct token accepted");
 
     console.log("ok!");

--- a/javascript/integration-tests/browser-tests/dashboard.test.js
+++ b/javascript/integration-tests/browser-tests/dashboard.test.js
@@ -47,7 +47,7 @@ it("share bundles between two pages", async () => {
         }
 
         await page1.reload();
-        await server.expect("disconnected.", 2000);
+        await server.expect("disconnected.");
 
         // Make sure server does not crash after page reload.
         await server.expect("got greeting", 5000);

--- a/javascript/integration-tests/expector-test.js
+++ b/javascript/integration-tests/expector-test.js
@@ -5,7 +5,7 @@ const Expector = require("./Expector");
     await expector.expect("two");
     while (true) {
         try {
-            await expector.expect("four", 100); // should throw after timeout
+            await expector.expect("four"); // should throw after timeout
         } catch {
             break;
         }
@@ -14,6 +14,20 @@ const Expector = require("./Expector");
     const catTest = new Expector("cat");
     catTest.send("hello world");
     await catTest.expect("hello");
+
+    // Process-exit test: expect() while process has already exited should reject
+    // with "process exited" message, not the timeout message.
+    const shortLived = new Expector("echo quick", [], { shell: true });
+    await shortLived.expect("quick"); // process exits after this
+    try {
+        await shortLived.expect("wont-appear", 5000);
+        throw new Error("expected expect() to reject when process has exited");
+    } catch (e) {
+        const msg = typeof e === "string" ? e : e.message;
+        if (!msg.includes("process exited") || !msg.includes("before expected string was seen"))
+            throw new Error("Expected rejection to mention process exited; got: " + msg);
+    }
+
     console.log("okay");
     process.exit(0);
 })();

--- a/javascript/integration-tests/py-py-test.js
+++ b/javascript/integration-tests/py-py-test.js
@@ -13,7 +13,7 @@ process.chdir(__dirname + "/..");
         "-l",
         `*:${port}`,
     ]);
-    await server.expect("listen", 2000);
+    await server.expect("listen");
 
     const client = new Expector("python3", [
         "-u",
@@ -23,15 +23,15 @@ process.chdir(__dirname + "/..");
         "-c",
         `ws://localhost:${port}`,
     ]);
-    await client.expect("connect", 2000);
-    await server.expect("accepted", 2000);
+    await client.expect("connect");
+    await server.expect("accepted");
 
     server.send("Directory(root=True).set(3,4);\n");
-    await server.expect("Muid", 1000);
+    await server.expect("Muid");
     await sleep(100);
 
     client.send("root.get(3);\n");
-    await client.expect("\n4\n", 1000);
+    await client.expect("\n4\n");
 
     await client.close();
     await server.close();

--- a/javascript/integration-tests/py-ts-test.js
+++ b/javascript/integration-tests/py-ts-test.js
@@ -12,7 +12,7 @@ let server = null;
         ["-l", port, "--verbose"],
         { env: { ...process.env } },
     );
-    await server.expect("node.gink", 2000);
+    await server.expect("node.gink");
 
     client = new Expector("python3", [
         "-u",
@@ -27,11 +27,11 @@ let server = null;
     await sleep(100);
 
     server.send("await root.set(3,4, {comment:'test bundle'});\n");
-    await server.expect("added bundle", 1000);
+    await server.expect("added bundle");
     await sleep(100);
 
     client.send("root.get(3);\n");
-    await client.expect("\n4.0\n", 1000);
+    await client.expect("\n4.0\n");
     await sleep(100);
 
     await client.close();

--- a/javascript/integration-tests/remote-listener-test.js
+++ b/javascript/integration-tests/remote-listener-test.js
@@ -17,7 +17,7 @@ process.chdir(__dirname + "/..");
         { env: { ...process.env } },
         false,
     );
-    await server.expect("node.gink", 2000);
+    await server.expect("node.gink");
 
     const client1 = new Database();
     await client1.connectTo(`ws://localhost:${port}`, {

--- a/javascript/integration-tests/ssl-py-server-test.js
+++ b/javascript/integration-tests/ssl-py-server-test.js
@@ -18,7 +18,7 @@ process.chdir(__dirname + "/..");
         "--ssl-key",
         "/etc/ssl/certs/localhost.key",
     ]);
-    await server.expect("secure", 2000);
+    await server.expect("secure");
 
     const client = new Expector("python3", [
         "-u",
@@ -36,7 +36,7 @@ process.chdir(__dirname + "/..");
     await sleep(100);
 
     client.send("root.get(3);\n");
-    await client.expect("\n4\n", 1000);
+    await client.expect("\n4\n");
     await sleep(100);
 
     await client.close();

--- a/javascript/integration-tests/ssl-ts-server-test.js
+++ b/javascript/integration-tests/ssl-ts-server-test.js
@@ -21,8 +21,8 @@ process.chdir(__dirname + "/..");
             env: { ...process.env },
         },
     );
-    await server.expect("Secure", 2000);
-    await server.expect("ready", 2000);
+    await server.expect("Secure");
+    await server.expect("ready");
 
     const client = new Expector("python3", [
         "-u",
@@ -37,11 +37,11 @@ process.chdir(__dirname + "/..");
     await sleep(100);
 
     server.send("await root.set(3,4, 'test bundle');\n");
-    await server.expect("added bundle", 1000);
+    await server.expect("added bundle");
     await sleep(100);
 
     client.send("root.get(3);\n");
-    await client.expect("\n4.0\n", 1000);
+    await client.expect("\n4.0\n");
     await sleep(100);
 
     await client.close();

--- a/javascript/integration-tests/ts-py-test.js
+++ b/javascript/integration-tests/ts-py-test.js
@@ -13,7 +13,7 @@ process.chdir(__dirname + "/..");
         "-l",
         `*:${port}`,
     ]);
-    await python.expect("listen", 2000);
+    await python.expect("listen");
     await sleep(500);
 
     const client = new Expector(
@@ -27,15 +27,15 @@ process.chdir(__dirname + "/..");
         ],
         { env: { ...process.env } },
     );
-    await python.expect("connection established!", 2000);
-    await client.expect("connected!", 2000);
+    await python.expect("connection established!");
+    await client.expect("connected!");
 
     python.send("Directory(root=True).set(3,4);\n");
-    await python.expect("Muid", 2000);
+    await python.expect("Muid");
 
     await sleep(100);
     client.send("await root.get(3);\n");
-    await client.expect("\n4n\n", 2000);
+    await client.expect("\n4n\n");
 
     await python.close();
     await client.close();
@@ -45,7 +45,7 @@ process.chdir(__dirname + "/..");
     /*
     await client.close();
 
-    await client.expect("reconnecting", 2000);
+    await client.expect("reconnecting");
 
     const python2 = new Expector("python3", [
         "-u",
@@ -55,9 +55,9 @@ process.chdir(__dirname + "/..");
         "-l",
         `*:${port}`,
     ]);
-    await python2.expect("listen", 2000);
+    await python2.expect("listen");
 
-    await client.expect("got greeting", 2000);
+    await client.expect("got greeting");
 
     await client.close();
     await python2.close();

--- a/javascript/integration-tests/wsgi-test.js
+++ b/javascript/integration-tests/wsgi-test.js
@@ -15,7 +15,7 @@ process.chdir(__dirname + "/..");
         "--wsgi_listen_on",
         `*:${port}`,
     ]);
-    await server.expect("listening", 2000);
+    await server.expect("listening");
     await sleep(500);
 
     const result = (

--- a/packages.txt
+++ b/packages.txt
@@ -15,7 +15,6 @@ unzip
 curl
 python3-typeshed
 ca-certificates
-python3-authlib
 python3-typeguard
 python3-nacl
 python3-dateutil

--- a/python/gink/__init__.py
+++ b/python/gink/__init__.py
@@ -29,6 +29,9 @@ from .impl.looping import loop
 from .impl.typedefs import (
     inf, GenericTimestamp, Request, AUTH_FULL, AUTH_NONE, AUTH_RITE, AUTH_READ, AUTH_WRITE, AuthFunc
 )
+from sys import version_info
+if version_info < (3, 12):
+    raise RuntimeError("Gink requires Python 3.12 or newer.")
 
 
 __all__ = [

--- a/python/gink/impl/utilities.py
+++ b/python/gink/impl/utilities.py
@@ -10,8 +10,6 @@ from datetime import datetime, date, timedelta
 from re import fullmatch, IGNORECASE, search, sub, split, Match
 from psutil import pid_exists
 from requests import get
-from authlib.jose import jwt, JsonWebKey, KeySet
-from authlib.jose.errors import JoseError
 from time import time as get_time
 from typing import *
 from random import choice
@@ -205,39 +203,6 @@ def normalize_pair(pair: Tuple[Any, Any]) -> Tuple[Muid, Muid]:
     if not left or not rite:
         raise ValueError("pair tuple can only contain 2 containers or muids")
     return left, rite
-
-
-# URL to get Google's public keys
-GOOGLE_CERTS_URL = 'https://www.googleapis.com/oauth2/v3/certs'
-
-_public_keys: Optional[KeySet] = None
-
-
-def decode_and_verify_jwt(token: bytes, app_id: Optional[str] = None) -> dict:
-    """ Get the useful claims from a jwt after deconstructing it. """
-    global _public_keys
-    if _public_keys is None:
-        response = get(GOOGLE_CERTS_URL)
-        response.raise_for_status()
-        jwks = response.json()
-        _public_keys = JsonWebKey.import_key_set(jwks)
-    try:
-        decoded = jwt.decode(token, _public_keys)
-        decoded.validate()
-    except JoseError as jose_error:
-        raise ValueError(jose_error)
-    if decoded.get('iss') not in ("https://accounts.google.com", "accounts.google.com"):
-        raise ValueError("not the issuer I expected")
-    if not decoded.get("email_verified"):
-        raise ValueError("email not verified")
-    if (decoded.get("exp") or 0) < get_time():
-        raise ValueError("jwt expired")
-    if app_id is not None and decoded.get("aud") != app_id:
-        raise ValueError("app id is not what I expected")
-    result = {}
-    for key in ["sub", "email", "name", "given_name", "family_name"]:
-        result[key] = decoded[key]
-    return result
 
 
 def generate_random_token() -> str:

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,10 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 from os import environ
+from sys import version_info
+
+if version_info < (3, 12):
+    raise RuntimeError("This project requires Python 3.12 or newer.")
 
 
 setup(
@@ -26,7 +30,6 @@ setup(
         "lmdb",
         "protobuf",
         "psutil",
-        "authlib",
         "typeguard",
         "pynacl",
         "python-dateutil",


### PR DESCRIPTION
Changes:

Removed authlib dependency and unused JWT/OAuth Google authentication functionality from Python code
Added Python 3.12 minimum version requirement with runtime checks in both setup.py and init.py
Increased default Expector.js timeout from 1000ms to 5000ms and improved process exit detection
Removed explicit short timeouts from integration tests to rely on the new 5000ms default
Added javascript/node_modules as a Makefile dependency