### PR TITLE
switched from nose2 to pytest

### DIFF
--- a/.github/workflows/macos-integration.yml
+++ b/.github/workflows/macos-integration.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Python packages
         run: cd ../python && pip3 install .[test] --break-system-packages
       - name: Run Python unit tests
-        run: cd ../python && nose2
+        run: cd ../python && python3 -m pytest
       - name: Run JS unit tests
         run: npm run test
       - name: Run JS integration tests

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ data.json
 *.db
 *.db-lock
 .venv
+PR.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mypy gink/impl gink/tests
 RUN pycodestyle --max-line-length=120 --select=E501 gink/impl/*.py gink/tests/*.py
 
 # Python unit-tests
-RUN python3 -m nose2
+RUN python3 -m pytest
 
 WORKDIR $GINK
 COPY javascript/*.js javascript/.prettier* ./javascript/

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ on-main-and-clean:
 	bash -c 'test -z "$$(git status --porcelain)"'
 
 test-python:
-	cd python && python3 -m nose2
+	cd python && python3 -m pytest
 
 test-javascript:
 	cd javascript && npm test

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,13 +45,13 @@ Ensure you are in the gink/python directory. \
 Run all unit tests
 
 ```sh
-nose2
+python3 -m pytest
 ```
 
 Run a specific unit test
 
 ```sh
-nose2 gink.tests.test_module.test_name
+python3 -m pytest gink/tests/test_module.py::test_name
 ```
 
 Run integration tests

--- a/packages.txt
+++ b/packages.txt
@@ -1,6 +1,6 @@
 npm
 protobuf-compiler
-python3-nose2
+python3-pytest
 mypy
 python3-requests
 python3-flask

--- a/ports.txt
+++ b/ports.txt
@@ -1,0 +1,11 @@
+py312-sortedcontainers
+py312-protobuf3
+py312-pynacl
+py312-pynose
+py312-flask-cors
+py312-lmdb
+py312-psutil
+py312-typeguard
+py312-dateutil
+py312-wsproto
+py312-pytest

--- a/python/gink/tests/__main__.py
+++ b/python/gink/tests/__main__.py
@@ -1,7 +1,7 @@
 from os import chdir
 from sys import exit
 from pathlib import Path
-from nose2 import discover  # type: ignore
+import pytest
 
 chdir(Path(__file__).parent)
-exit(discover())
+exit(pytest.main())

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    ignore:.* is experimental:DeprecationWarning
+    ignore:.*utcfromtimestamp\(\) is deprecated.*:DeprecationWarning:google\.protobuf\.internal\.well_known_types

--- a/python/setup.py
+++ b/python/setup.py
@@ -37,7 +37,7 @@ setup(
         "requests",
     ],
     extras_require={
-        "test": ["nose2", "flask"],
+        "test": ["pytest", "flask"],
         "lint": ["mypy"],
         "performance": ["matplotlib"],
         "docs": [


### PR DESCRIPTION
## Switch Python tests from nose2 to pytest

This PR performs a minimal migration from `nose2` to `pytest` so the existing test suite continues to run with as few code changes as possible.

### What changed

- Updated Python test invocation in `Makefile`:
  - `test-python` now runs `cd python && python3 -m pytest`
- Updated Debian package dependency in `packages.txt`:
  - Replaced `python3-nose2` with `python3-pytest`
- Updated Python package test extras in `python/setup.py`:
  - Replaced `nose2` with `pytest` in `extras_require["test"]`
- Updated test package entrypoint in `python/gink/tests/__main__.py`:
  - Replaced `nose2.discover()` with `pytest.main()`
- Updated other project test runners to stay consistent:
  - `Dockerfile` now runs `python3 -m pytest`
  - `.github/workflows/macos-integration.yml` now runs `python3 -m pytest`
- Updated developer docs in `docs/development.md`:
  - Replaced `nose2` examples with `python3 -m pytest` equivalents
- Added pytest warning filtering in `python/pytest.ini`:
  - Suppresses project-specific experimental warnings: `DeprecationWarning: ... is experimental`
  - Suppresses protobuf's Python 3.12 deprecation warning about `utcfromtimestamp()`

### Test validation

- Ran the suite using `/opt/local/bin/python3.12` from `python/`:
  - Command: `/opt/local/bin/python3.12 -m pytest`
  - Result: `133 passed` (warning summary fully suppressed by configured filters)