### PR TITLE
Close file-backed store watchers

### DIFF
--- a/python/gink/impl/abstract_store.py
+++ b/python/gink/impl/abstract_store.py
@@ -99,6 +99,7 @@ class AbstractStore(BundleStore, Generic[Lock]):
 
     def close(self):
         """Safely releases resources."""
+        super().close()
 
     @abstractmethod
     def _refresh_helper(self, lock: Lock, callback: Optional[Callable[[Decomposition], None]]=None, /) -> int:

--- a/python/gink/impl/bundle_store.py
+++ b/python/gink/impl/bundle_store.py
@@ -61,9 +61,10 @@ class BundleStore(Selectable):
         """ Return the underlying file name, or None if the store isn't file backed.
         """
 
-    @abstractmethod
     def close(self):
-        """ free resources """
+        """Close resources shared by all bundle stores."""
+        if hasattr(self, "_watcher"):
+            getattr(self, "_watcher").close()
 
     def is_closed(self) -> bool:
         """ Return true if closed """

--- a/python/gink/impl/lmdb_store.py
+++ b/python/gink/impl/lmdb_store.py
@@ -683,6 +683,7 @@ class LmdbStore(AbstractStore):
             to_process = to_last_with_prefix(cursor, container, boundary=limit)
 
     def close(self):
+        super().close()
         self._handle.close()
         if self._temporary:
             self._file_path.unlink(missing_ok=True)

--- a/python/gink/impl/log_backed_store.py
+++ b/python/gink/impl/log_backed_store.py
@@ -164,6 +164,7 @@ class LogBackedStore(MemoryStore):
 
     def close(self):
         """Closes the underlying file."""
+        super().close()
         self._handle.close()
         self._is_closed = True
 

--- a/python/gink/tests/test_lmdb_store.py
+++ b/python/gink/tests/test_lmdb_store.py
@@ -24,3 +24,15 @@ def test_bundle_no_retention():
     except ValueError:
         return
     raise AssertionError("expected get_bundles to barf")
+
+
+def test_close_closes_watcher():
+    """Closing a file-backed store must release its inotify instance."""
+    store = LmdbStore()
+    assert store.is_selectable()
+    watcher = store._get_watcher()
+    assert watcher is not None and not watcher.closed
+
+    store.close()
+
+    assert watcher.closed


### PR DESCRIPTION
## Summary

- close the shared inotify watcher when a bundle store is closed
- make LMDB and log-backed stores chain through the shared cleanup
- add a regression test proving that closing an LMDB store closes its watcher

## Why this matters

File-backed stores lazily create an inotify instance, but their `close()` methods previously closed only the database or log handle. The watcher remained open, so the Python test process accumulated instances until it reached Linux `fs.inotify.max_user_instances` (128). At that point `inotify_init1()` failed with `OSError: [Errno 24] Too many open files`, even though the ordinary file-descriptor limit was 524,288.

Explicitly closing the watcher fixes the resource leak instead of masking it by raising a host-wide limit.

## Verification

- `make test`
- Python: 134 passed
- JavaScript: 123 passed across 23 suites