### PR TITLE
Re-enable disabled integration tests

### DIFF
--- a/javascript/implementation/LogBackedStore.ts
+++ b/javascript/implementation/LogBackedStore.ts
@@ -205,7 +205,11 @@ export class LogBackedStore extends LockableLog implements Store {
         for (const bundleBytes of bundles) {
             const bundle: BundleView = new Decomposition(bundleBytes);
             const added = await this.internalStore.addBundle(bundle);
-            if (!added) throw new Error("unexpected not added");
+            // A bundle can already be present when a file-watch pull races with
+            // another path that adds the same bundle. Store.addBundle is
+            // intentionally idempotent, so only broadcast bundles that this
+            // pull actually discovered.
+            if (!added) continue;
             const info = bundle.info;
             const identity = bundle.builder.getIdentity();
             this.hasMap.markAsHaving(bundle.info);

--- a/javascript/integration-tests/chain-reuse-ts-test.js
+++ b/javascript/integration-tests/chain-reuse-ts-test.js
@@ -7,7 +7,6 @@ process.chdir(__dirname + "/..");
 let result = 1;
 let instance;
 let instance2;
-process.exit(0); // TODO: fix
 (async () => {
     console.log("starting");
     if (existsSync(TEST_DB_PATH)) {

--- a/javascript/integration-tests/logbacked-peers-test.js
+++ b/javascript/integration-tests/logbacked-peers-test.js
@@ -14,28 +14,29 @@ Logbacked1 <- Share File -> Logbacked2
 Ensures if logbacked1 changes the file, logbacked2 will
 automatically pull the changes and broadcast them.
 */
-process.exit(0); // TODO: FIXME
 process.chdir(__dirname + "/..");
 let server = null;
 let result = 1;
 (async () => {
     const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     console.log("starting");
-    server = new Expector("./tsc.out/implementation/main.js", ["-l", port], {
-        env: { ...process.env },
-    });
-    await server.expect("listening", 10000);
+    server = new Expector(
+        "./tsc.out/implementation/main.js",
+        ["-l", port, "--verbose"],
+        { env: { ...process.env } },
+    );
+    await server.expect("SimpleServer.ready", 10000);
     console.log("server started");
 
     const path = "/tmp/test_peer.store";
 
     if (existsSync(path)) unlinkSync(path);
     const lbstore1 = new LogBackedStore(path);
-    const instance1 = new Database(lbstore1);
+    const instance1 = new Database({ store: lbstore1 });
     await instance1.ready;
 
     const lbstore2 = new LogBackedStore(path);
-    const instance2 = new Database(lbstore2);
+    const instance2 = new Database({ store: lbstore2 });
     await instance2.ready;
     await instance2.connectTo(`ws://localhost:${port}`);
     console.log("second store connected to server");
@@ -43,8 +44,9 @@ let result = 1;
     await Directory.get(instance1).set("foo", "bar", "testing peer callback");
     console.log("wrote to first instance");
 
-    await new Promise((r) => setTimeout(r, 100));
-    await server.expect(/received bundle:.*testing peer callback/, 10000);
+    await server.expect("added bundle from 1", 10000);
+    server.send('console.log(await root.get("foo"));\n');
+    await server.expect("bar");
     console.log("received expected bundle");
     result = 0;
 })()

--- a/javascript/integration-tests/node-client-test.js
+++ b/javascript/integration-tests/node-client-test.js
@@ -4,27 +4,33 @@ process.chdir(__dirname + "/..");
 let server = null;
 let client = null;
 let result = 1;
-process.exit(0); // TODO: FIXME
 (async () => {
     const port = process.env.CURRENT_SAFE_PORT ?? 8080;
     console.log("starting");
-    server = new Expector("./tsc.out/implementation/main.js", ["-l", port], {
-        env: { ...process.env },
-    });
-    await server.expect("listening", 10000);
+    server = new Expector(
+        "./tsc.out/implementation/main.js",
+        ["-l", port, "--verbose"],
+        { env: { ...process.env } },
+    );
+    await server.expect("SimpleServer.ready", 10000);
     client = new Expector("./tsc.out/implementation/main.js", [
         "-c",
         `ws://127.0.0.1:${port}/`,
+        "--verbose",
     ]);
-    await client.expect("using", 10000);
+    await client.expect("connected!", 10000);
     console.log("all ready");
 
     server.send("var misc = await root.set('x', 'y', 'hello'); \r\n");
     console.log("sent");
-    await client.expect(/received bundle:.*hello/);
+    await client.expect("added bundle from 1");
+    client.send("console.log(await root.get('x'));\n");
+    await client.expect("y");
     console.log("received");
     client.send("var misc = await root.set('a', 'b', 'world'); \r\n");
-    await server.expect(/received bundle:.*world/);
+    await server.expect("added bundle from 1");
+    server.send("console.log(await root.get('a'));\n");
+    await server.expect("b");
 
     console.log("closing...");
     console.log("ok!");
@@ -34,7 +40,7 @@ process.exit(0); // TODO: FIXME
         console.error(reason);
     })
     .finally(async () => {
-        await server.close();
-        await client.close();
+        if (server) await server.close();
+        if (client) await client.close();
         process.exit(result);
     });


### PR DESCRIPTION
## Summary

- re-enable the TypeScript chain-reuse, log-backed peer, and Node client integration tests
- update the peer tests to wait for current verbose CLI readiness signals and assert replicated values instead of obsolete comment-bearing log messages
- pass `LogBackedStore` through the current `Database({ store })` constructor API so the log-backed test exercises its intended storage path
- make log-file replay tolerate an already-present bundle, preserving `Store.addBundle` idempotence and avoiding duplicate broadcasts when concurrent file-watch and sync paths race
- make Node client cleanup safe when setup fails partway through

## Why fixes were needed

The chain-reuse test passes as written once its early exit is removed. The other two tests had drifted from current CLI output and APIs. The log-backed test additionally exposed a real concurrency issue: two pull paths can observe the same log range, and the second replay previously threw even though duplicate bundle insertion is defined to return false. Skipping that already-known bundle is safe and ensures callbacks only broadcast newly discovered data.

## Verification

- `npm run build`
- `npm test -- --runInBand` (23 suites, 123 tests)
- `npm run test-integration`
- each updated network integration test passed three consecutive isolated runs